### PR TITLE
Update to version 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to 
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html). Please note this changelog affects this package and not the 
+cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
+detailed information.
+
+## [1.6.0]
+
+### Added
+
+- Add database users endpoint.
+- Add mail aliases endpoint.
+- Add `balancer_backend_name` to virtualhosts.
+- Add `catch_all_forward_email_addresses` to mail domain.
+- Add commit call to the cluster endpoint. See the [readme](readme.md) for more information.
+
+### Changed
+
+- Update to [API version 1.12](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.12-2021-02-23)
+
+### Removed
+
+- Remove `forward_email_addresses` from mail accounts.
 
 ## [1.5.0]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.9** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.12** version of the API.
 
 This package is not created or maintained by Cyberfusion.
 
@@ -91,6 +91,27 @@ When models need to be provided, the required properties will be checked before 
 
 When you want to use the API directly, you can use the `request()` method on the `Client`. This method needs a `Request`
 class. See the class itself for its options.
+
+#### Committing changes
+
+A commit is required when you perform a create/update/delete for:
+
+- mail aliases 
+- mail accounts
+- mail domains
+- ssh keys
+- unix users
+- fpm pools
+- crons
+- virtual hosts
+  
+**_You **MUST** commit the changes for each cluster as this is required to update the cluster!_**
+
+```php
+$api
+    ->clusters()
+    ->commit($clusterId);
+```
 
 ### Responses
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "analyse": "vendor/bin/psalm"
     },
     "config": {
         "sort-packages": true

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -43,6 +43,16 @@ class ClusterApi
         return new Endpoints\Crons($this->client);
     }
 
+    public function databases(): Endpoints\Databases
+    {
+        return new Endpoints\Databases($this->client);
+    }
+
+    public function databaseUsers(): Endpoints\DatabaseUsers
+    {
+        return new Endpoints\DatabaseUsers($this->client);
+    }
+
     public function fpmPools(): Endpoints\FpmPools
     {
         return new Endpoints\FpmPools($this->client);
@@ -61,6 +71,11 @@ class ClusterApi
     public function mailAccounts(): Endpoints\MailAccounts
     {
         return new Endpoints\MailAccounts($this->client);
+    }
+
+    public function mailAliases(): Endpoints\MailAliases
+    {
+        return new Endpoints\MailAliases($this->client);
     }
 
     public function mailDomains(): Endpoints\MailDomains

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -64,4 +64,30 @@ class Clusters extends Endpoint
             'cluster' => (new Cluster())->fromArray($response->getData()),
         ]);
     }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function commit(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('clusters/cluster-deployments')
+            ->setBody([
+                'id' => $id,
+            ]);
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'cluster' => (new Cluster())->fromArray($response->getData()),
+        ]);
+    }
 }

--- a/src/Endpoints/DatabaseUsers.php
+++ b/src/Endpoints/DatabaseUsers.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\DatabaseUser;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+
+class DatabaseUsers extends Endpoint
+{
+    /**
+     * @param ListFilter|null $filter
+     * @return Response
+     * @throws RequestException
+     */
+    public function list(ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('database-users?%s', http_build_query($filter->toArray())));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'databaseUsers' => array_map(
+                function (array $data) {
+                    return (new DatabaseUser())->fromArray($data);
+                },
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('database-users/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'databaseUser' => (new DatabaseUser())->fromArray($response->getData()),
+        ]);
+    }
+}

--- a/src/Endpoints/MailAccounts.php
+++ b/src/Endpoints/MailAccounts.php
@@ -99,7 +99,6 @@ class MailAccounts extends Endpoint
         $requiredAttributes = [
             'localPart',
             'password',
-            'forwardEmailAddresses',
             'mailDomainId',
         ];
         $this->validateRequired($mailAccount, 'create', $requiredAttributes);
@@ -110,7 +109,6 @@ class MailAccounts extends Endpoint
             ->setBody($this->filterFields($mailAccount->toArray(), [
                 'local_part',
                 'password',
-                'forward_email_addresses',
                 'quota',
                 'mail_domain_id',
             ]));
@@ -137,7 +135,6 @@ class MailAccounts extends Endpoint
         $requiredAttributes = [
             'localPart',
             'password',
-            'forwardEmailAddresses',
             'mailDomainId',
             'id',
             'clusterId'
@@ -150,7 +147,6 @@ class MailAccounts extends Endpoint
             ->setBody($this->filterFields($mailAccount->toArray(), [
                 'local_part',
                 'password',
-                'forward_email_addresses',
                 'quota',
                 'mail_domain_id',
                 'id',

--- a/src/Endpoints/MailAliases.php
+++ b/src/Endpoints/MailAliases.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\MailAlias;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+
+class MailAliases extends Endpoint
+{
+    /**
+     * @param ListFilter|null $filter
+     * @return Response
+     * @throws RequestException
+     */
+    public function list(ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('mail-aliases?%s', http_build_query($filter->toArray())));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'mailAliases' => array_map(
+                function (array $data) {
+                    return (new MailAlias())->fromArray($data);
+                },
+                $response->getData()
+            )
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('mail-aliases/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'mailAlias' => (new MailAlias())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param MailAlias $mailAlias
+     * @return Response
+     * @throws RequestException
+     */
+    public function create(MailAlias $mailAlias): Response
+    {
+        $requiredAttributes = [
+            'localPart',
+            'forwardEmailAddresses',
+            'mailDomainId',
+        ];
+        $this->validateRequired($mailAlias, 'create', $requiredAttributes);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('mail-aliases')
+            ->setBody($this->filterFields($mailAlias->toArray(), [
+                'local_part',
+                'forward_email_addresses',
+                'mail_domain_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'mailAlias' => (new MailAlias())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param MailAlias $mailAlias
+     * @return Response
+     * @throws RequestException
+     */
+    public function update(MailAlias $mailAlias): Response
+    {
+        $requiredAttributes = [
+            'localPart',
+            'forwardEmailAddresses',
+            'mailDomainId',
+            'id',
+            'clusterId'
+        ];
+        $this->validateRequired($mailAlias, 'update', $requiredAttributes);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('mail-aliases/%d', $mailAlias->id))
+            ->setBody($this->filterFields($mailAlias->toArray(), [
+                'local_part',
+                'forward_email_addresses',
+                'mail_domain_id',
+                'id',
+                'cluster_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'mailAlias' => (new MailAlias())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('mail-aliases/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Endpoints/MailDomains.php
+++ b/src/Endpoints/MailDomains.php
@@ -74,6 +74,7 @@ class MailDomains extends Endpoint
     {
         $requiredAttributes = [
             'domain',
+            'catchAllForwardEmailAddresses',
             'unixUserId',
         ];
         $this->validateRequired($mailDomain, 'create', $requiredAttributes);
@@ -83,6 +84,7 @@ class MailDomains extends Endpoint
             ->setUrl('mail-domains')
             ->setBody($this->filterFields($mailDomain->toArray(), [
                 'domain',
+                'catch_all_forward_email_addresses',
                 'unix_user_id',
             ]));
 

--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -79,6 +79,7 @@ class VirtualHosts extends Endpoint
             'documentRoot',
             'publicRoot',
             'forceSsl',
+            'balancerBackendName',
         ];
         $this->validateRequired($virtualHost, 'create', $requiredAttributes);
 
@@ -94,6 +95,7 @@ class VirtualHosts extends Endpoint
                 'fpm_pool_id',
                 'force_ssl',
                 'custom_config',
+                'balancer_backend_name',
                 'deploy_commands',
             ]));
 
@@ -125,6 +127,7 @@ class VirtualHosts extends Endpoint
             'forceSsl',
             'id',
             'clusterId',
+            'balancerBackendName',
         ];
         $this->validateRequired($virtualHost, 'update', $requiredAttributes);
 
@@ -140,6 +143,7 @@ class VirtualHosts extends Endpoint
                 'fpm_pool_id',
                 'force_ssl',
                 'custom_config',
+                'balancer_backend_name',
                 'deploy_commands',
                 'id',
                 'cluster_id',

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+
+class DatabaseUser implements Model
+{
+    public string $name;
+    public ?int $id = null;
+    public ?int $clusterId = null;
+    public ?string $createdAt = null;
+    public ?string $updatedAt = null;
+
+    public function fromArray(array $data): DatabaseUser
+    {
+        $databaseUser = new self();
+        $databaseUser->name = Arr::get($data, 'name');
+        $databaseUser->id = Arr::get($data, 'id');
+        $databaseUser->clusterId = Arr::get($data, 'cluster_id');
+        $databaseUser->createdAt = Arr::get($data, 'created_at');
+        $databaseUser->updatedAt = Arr::get($data, 'updated_at');
+        return $databaseUser;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'id' => $this->id,
+            'cluster_id' => $this->clusterId,
+            'created_at' => $this->createdAt,
+            'updated_at' => $this->updatedAt,
+        ];
+    }
+}

--- a/src/Models/MailAccount.php
+++ b/src/Models/MailAccount.php
@@ -9,7 +9,6 @@ class MailAccount implements Model
 {
     public string $localPart;
     public string $password;
-    public array $forwardEmailAddresses = [];
     public ?int $quota = null;
     public int $mailDomainId;
     public ?int $id = null;
@@ -22,7 +21,6 @@ class MailAccount implements Model
         $mailAccount = new self();
         $mailAccount->localPart = Arr::get($data, 'local_part');
         $mailAccount->password = Arr::get($data, 'password');
-        $mailAccount->forwardEmailAddresses = Arr::get($data, 'forward_email_addresses', []);
         $mailAccount->quota = Arr::get($data, 'quota');
         $mailAccount->mailDomainId = Arr::get($data, 'mail_domain_id');
         $mailAccount->id = Arr::get($data, 'id');
@@ -37,7 +35,6 @@ class MailAccount implements Model
         return [
             'local_part' => $this->localPart,
             'password' => $this->password,
-            'forward_email_addresses' => $this->forwardEmailAddresses,
             'quota' => $this->quota,
             'mail_domain_id' => $this->mailDomainId,
             'id' => $this->id,

--- a/src/Models/MailAlias.php
+++ b/src/Models/MailAlias.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+
+class MailAlias implements Model
+{
+    public string $localPart;
+    public array $forwardEmailAddresses = [];
+    public ?int $mailDomainId = null;
+    public ?int $id = null;
+    public ?int $clusterId = null;
+    public ?string $createdAt = null;
+    public ?string $updatedAt = null;
+
+    public function fromArray(array $data): MailAlias
+    {
+        $mailAlias = new self();
+        $mailAlias->localPart = Arr::get($data, 'local_part');
+        $mailAlias->forwardEmailAddresses = Arr::get($data, 'forward_email_addresses', []);
+        $mailAlias->mailDomainId = Arr::get($data, 'mail_domain_id');
+        $mailAlias->id = Arr::get($data, 'id');
+        $mailAlias->clusterId = Arr::get($data, 'cluster_id');
+        $mailAlias->createdAt = Arr::get($data, 'created_at');
+        $mailAlias->updatedAt = Arr::get($data, 'updated_at');
+        return $mailAlias;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'local_part' => $this->localPart,
+            'forward_email_addresses' => $this->forwardEmailAddresses,
+            'mail_domain_id' => $this->mailDomainId,
+            'id' => $this->id,
+            'cluster_id' => $this->clusterId,
+            'created_at' => $this->createdAt,
+            'updated_at' => $this->updatedAt,
+        ];
+    }
+}

--- a/src/Models/MailDomain.php
+++ b/src/Models/MailDomain.php
@@ -8,6 +8,7 @@ use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 class MailDomain implements Model
 {
     public string $domain;
+    public array $catchAllForwardEmailAddresses = [];
     public int $unixUserId;
     public ?int $id = null;
     public ?int $clusterId = null;
@@ -18,6 +19,7 @@ class MailDomain implements Model
     {
         $mailDomain = new self();
         $mailDomain->domain = Arr::get($data, 'domain');
+        $mailDomain->catchAllForwardEmailAddresses = Arr::get($data, 'catch_all_forward_email_addresses', []);
         $mailDomain->unixUserId = Arr::get($data, 'unix_user_id');
         $mailDomain->id = Arr::get($data, 'id');
         $mailDomain->clusterId = Arr::get($data, 'cluster_id');
@@ -30,6 +32,7 @@ class MailDomain implements Model
     {
         return [
             'domain' => $this->domain,
+            'catch_all_forward_email_addresses' => $this->catchAllForwardEmailAddresses,
             'unix_user_id' => $this->unixUserId,
             'id' => $this->id,
             'cluster_id' => $this->clusterId,

--- a/src/Models/VirtualHost.php
+++ b/src/Models/VirtualHost.php
@@ -15,6 +15,7 @@ class VirtualHost implements Model
     public ?int $fpmPoolId = null;
     public bool $forceSsl = true;
     public ?string $customConfig = null;
+    public ?string $balancerBackendName = null;
     public array $deployCommands = [];
     public ?int $id = null;
     public ?int $clusterId = null;
@@ -31,6 +32,7 @@ class VirtualHost implements Model
         $virtualHost->publicRoot = Arr::get($data, 'public_root');
         $virtualHost->fpmPoolId = Arr::get($data, 'fpm_pool_id');
         $virtualHost->forceSsl = Arr::get($data, 'force_ssl');
+        $virtualHost->balancerBackendName = Arr::get($data, 'balancer_backend_name');
         $virtualHost->customConfig = Arr::get($data, 'custom_config');
         $virtualHost->deployCommands = Arr::get($data, 'deploy_commands', []);
         $virtualHost->id = Arr::get($data, 'id');
@@ -53,6 +55,7 @@ class VirtualHost implements Model
             'custom_config' => $this->customConfig,
             'id' => $this->id,
             'cluster_id' => $this->clusterId,
+            'balancer_backend_name' => $this->balancerBackendName,
             'deploy_commands' => $this->deployCommands,
             'created_at' => $this->createdAt,
             'updated_at' => $this->updatedAt,


### PR DESCRIPTION
### Added

- Add database users endpoint.
- Add mail aliases endpoint.
- Add `balancer_backend_name` to virtualhosts.
- Add `catch_all_forward_email_addresses` to mail domain.
- Add commit call to the cluster endpoint. See the [readme](readme.md) for more information.

### Changed

- Update to [API version 1.12](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.12-2021-02-23)

### Removed

- Remove `forward_email_addresses` from mail accounts.