### PR TITLE
Update to API version 1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.11.0]
+
+### Added
+
+- Add several attributes to clusters.
+- Add validation to several properties.
+
+### Changed
+
+- Update to [API version 1.28](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.28-2021-03-29)
+- Change to getters and setters for the properties to allow validation of the properties. To prevent breaking 
+  implementations, property access is still available but the use of the getters and setters is recommended.
+
 ## [1.10.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.19** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.28** version of the API.
 
 This package is not created or maintained by Cyberfusion.
 
@@ -73,11 +73,11 @@ The endpoint methods may ask for filters, models or id's. The method typehints w
 The endpoint may request a model, most create and update requests do. 
 
 ```php
-$unixUser = new UnixUser();
-$unixUser->username = 'foo';
-$unixUser->password = 'bar';
-$unixUser->defaultPhpVersion = '7.4';
-$unixUser->clusterId = 1;
+$unixUser = (new UnixUser())
+    ->setUsername('foo')
+    ->setPassword('bar')
+    ->setDefaultPhpVersion('7.4')
+    ->setClusterId(1);
 
 $result = $api
     ->unixUsers
@@ -152,9 +152,9 @@ $client = new Client($configuration, true);
 $api = new ClusterApi($client);
 
 // Create the request
-$login = new Login();
-$login->username = 'username';
-$login->password = 'password';
+$login = (new Login())
+    ->setUsername('username')
+    ->setPassword('password');
 
 // Perform the request
 $response = $api

--- a/src/Client.php
+++ b/src/Client.php
@@ -230,7 +230,7 @@ class Client implements ClientContract
      */
     private function parseBody(ResponseInterface $response): array
     {
-        $body = json_decode($response->getBody(), true);
+        $body = json_decode((string)$response->getBody(), true);
         if ($response->getStatusCode() < 300) {
             return $body;
         }

--- a/src/Endpoints/Certificates.php
+++ b/src/Endpoints/Certificates.php
@@ -72,9 +72,9 @@ class Certificates extends Endpoint
      */
     public function create(Certificate $certificate): Response
     {
-        $requiredAttributes = is_null($certificate->certificate)
-            ? ['commonNames', 'clusterId'] // Request Let's Encrypt certificate
-            : ['certificate', 'cachain', 'privateKey', 'clusterId']; // Supply own certificate
+        $requiredAttributes = is_null($certificate->getCertificate())
+            ? ['common_names', 'cluster_id'] // Request Let's Encrypt certificate
+            : ['certificate', 'ca_chain', 'private_key', 'cluster_id']; // Supply own certificate
         $this->validateRequired($certificate, 'create', $requiredAttributes);
 
         $request = (new Request())
@@ -107,15 +107,11 @@ class Certificates extends Endpoint
      */
     public function update(Certificate $certificate): Response
     {
-        $requiredAttributes = [
-            'id',
-            'clusterId'
-        ];
-        $this->validateRequired($certificate, 'update', $requiredAttributes);
+        $this->validateRequired($certificate, 'update', ['id', 'cluster_id']);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PATCH)
-            ->setUrl(sprintf('certificates/%d', $certificate->id))
+            ->setUrl(sprintf('certificates/%d', $certificate->getId()))
             ->setBody($this->filterFields($certificate->toArray(), [
                 'common_names',
                 'certificate',

--- a/src/Endpoints/Commands.php
+++ b/src/Endpoints/Commands.php
@@ -72,12 +72,11 @@ class Commands extends Endpoint
      */
     public function create(Command $command): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($command, 'create', [
             'command',
-            'secretValues',
-            'virtualHostId',
-        ];
-        $this->validateRequired($command, 'create', $requiredAttributes);
+            'secret_values',
+            'virtual_host_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -107,18 +106,17 @@ class Commands extends Endpoint
      */
     public function update(Command $command): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($command, 'update', [
             'command',
-            'secretValues',
-            'virtualHostId',
+            'secret_values',
+            'virtual_host_id',
             'id',
-            'clusterId',
-        ];
-        $this->validateRequired($command, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('commands/%d', $command->id))
+            ->setUrl(sprintf('commands/%d', $command->getId()))
             ->setBody($this->filterFields($command->toArray(), [
                 'command',
                 'secret_values',

--- a/src/Endpoints/Crons.php
+++ b/src/Endpoints/Crons.php
@@ -72,14 +72,13 @@ class Crons extends Endpoint
      */
     public function create(Cron $cron): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($cron, 'create', [
             'name',
             'command',
-            'emailAddress',
+            'email_address',
             'schedule',
-            'unixUserId'
-        ];
-        $this->validateRequired($cron, 'create', $requiredAttributes);
+            'unix_user_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -112,20 +111,19 @@ class Crons extends Endpoint
      */
     public function update(Cron $cron): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($cron, 'update', [
             'name',
             'command',
-            'emailAddress',
+            'email_address',
             'schedule',
-            'unixUserId',
+            'unix_user_id',
             'id',
-            'clusterId',
-        ];
-        $this->validateRequired($cron, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('crons/%d', $cron->id))
+            ->setUrl(sprintf('crons/%d', $cron->getId()))
             ->setBody($this->filterFields($cron->toArray(), [
                 'name',
                 'command',

--- a/src/Endpoints/DatabaseUserGrants.php
+++ b/src/Endpoints/DatabaseUserGrants.php
@@ -72,13 +72,12 @@ class DatabaseUserGrants extends Endpoint
      */
     public function create(DatabaseUserGrant $databaseUserGrant): Response
     {
-        $requiredAttributes = [
-            'databaseId',
-            'databaseUserId',
-            'tableName',
-            'privilegeName',
-        ];
-        $this->validateRequired($databaseUserGrant, 'create', $requiredAttributes);
+        $this->validateRequired($databaseUserGrant, 'create', [
+            'database_id',
+            'database_user_id',
+            'table_name',
+            'privilege_name',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)

--- a/src/Endpoints/DatabaseUsers.php
+++ b/src/Endpoints/DatabaseUsers.php
@@ -72,13 +72,12 @@ class DatabaseUsers extends Endpoint
      */
     public function create(DatabaseUser $databaseUser): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($databaseUser, 'create', [
             'name',
             'password',
-            'serverSoftwareName',
-            'clusterId',
-        ];
-        $this->validateRequired($databaseUser, 'create', $requiredAttributes);
+            'server_software_name',
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -110,18 +109,17 @@ class DatabaseUsers extends Endpoint
      */
     public function update(DatabaseUser $databaseUser): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($databaseUser, 'update', [
             'id',
             'name',
             'password',
-            'serverSoftwareName',
-            'clusterId',
-        ];
-        $this->validateRequired($databaseUser, 'update', $requiredAttributes);
+            'server_software_name',
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('database-users/%d', $databaseUser->id))
+            ->setUrl(sprintf('database-users/%d', $databaseUser->getId()))
             ->setBody($this->filterFields($databaseUser->toArray(), [
                 'name',
                 'host',

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -74,12 +74,11 @@ class Databases extends Endpoint
      */
     public function create(Database $database): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($database, 'create', [
             'name',
-            'serverSoftwareName',
-            'clusterId',
-        ];
-        $this->validateRequired($database, 'create', $requiredAttributes);
+            'server_software_name',
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -29,9 +29,16 @@ abstract class Endpoint
      */
     protected function validateRequired(Model $model, string $action, array $requiredAttributes = []): void
     {
+        $modelFields = $model->toArray();
+
         $missing = [];
         foreach ($requiredAttributes as $requiredAttribute) {
-            $value = $model->{$requiredAttribute};
+            $value = $modelFields[$requiredAttribute] ?? null;
+            if (is_null($value)) {
+                $missing[] = $requiredAttribute;
+                continue;
+            }
+
             if (is_string($value) && trim($value) === '') {
                 $missing[] = $requiredAttribute;
             }

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -72,13 +72,12 @@ class FpmPools extends Endpoint
      */
     public function create(FpmPool $fpmPool): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($fpmPool, 'create', [
             'name',
-            'unixUserId',
+            'unix_user_id',
             'version',
-            'maxChildren',
-        ];
-        $this->validateRequired($fpmPool, 'create', $requiredAttributes);
+            'max_children',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -112,15 +111,14 @@ class FpmPools extends Endpoint
      */
     public function update(FpmPool $fpmPool): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($fpmPool, 'update', [
             'id',
-            'clusterId'
-        ];
-        $this->validateRequired($fpmPool, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('fpm-pools/%d', $fpmPool->id))
+            ->setUrl(sprintf('fpm-pools/%d', $fpmPool->getId()))
             ->setBody($this->filterFields($fpmPool->toArray(), [
                 'name',
                 'unix_user_id',

--- a/src/Endpoints/MailAccounts.php
+++ b/src/Endpoints/MailAccounts.php
@@ -103,12 +103,11 @@ class MailAccounts extends Endpoint
      */
     public function create(MailAccount $mailAccount): Response
     {
-        $requiredAttributes = [
-            'localPart',
+        $this->validateRequired($mailAccount, 'create', [
+            'local_part',
             'password',
-            'mailDomainId',
-        ];
-        $this->validateRequired($mailAccount, 'create', $requiredAttributes);
+            'mail_domain_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -139,18 +138,17 @@ class MailAccounts extends Endpoint
      */
     public function update(MailAccount $mailAccount): Response
     {
-        $requiredAttributes = [
-            'localPart',
+        $this->validateRequired($mailAccount, 'update', [
+            'local_part',
             'password',
-            'mailDomainId',
+            'mail_domain_id',
             'id',
-            'clusterId'
-        ];
-        $this->validateRequired($mailAccount, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('mail-accounts/%d', $mailAccount->id))
+            ->setUrl(sprintf('mail-accounts/%d', $mailAccount->getId()))
             ->setBody($this->filterFields($mailAccount->toArray(), [
                 'local_part',
                 'password',

--- a/src/Endpoints/MailAliases.php
+++ b/src/Endpoints/MailAliases.php
@@ -72,12 +72,11 @@ class MailAliases extends Endpoint
      */
     public function create(MailAlias $mailAlias): Response
     {
-        $requiredAttributes = [
-            'localPart',
-            'forwardEmailAddresses',
-            'mailDomainId',
-        ];
-        $this->validateRequired($mailAlias, 'create', $requiredAttributes);
+        $this->validateRequired($mailAlias, 'create', [
+            'local_part',
+            'forward_email_addresses',
+            'mail_domain_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -107,18 +106,17 @@ class MailAliases extends Endpoint
      */
     public function update(MailAlias $mailAlias): Response
     {
-        $requiredAttributes = [
-            'localPart',
-            'forwardEmailAddresses',
-            'mailDomainId',
+        $this->validateRequired($mailAlias, 'update', [
+            'local_part',
+            'forward_email_addresses',
+            'mail_domain_id',
             'id',
-            'clusterId'
-        ];
-        $this->validateRequired($mailAlias, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('mail-aliases/%d', $mailAlias->id))
+            ->setUrl(sprintf('mail-aliases/%d', $mailAlias->getId()))
             ->setBody($this->filterFields($mailAlias->toArray(), [
                 'local_part',
                 'forward_email_addresses',

--- a/src/Endpoints/MailDomains.php
+++ b/src/Endpoints/MailDomains.php
@@ -72,13 +72,12 @@ class MailDomains extends Endpoint
      */
     public function create(MailDomain $mailDomain): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($mailDomain, 'create', [
             'domain',
-            'catchAllForwardEmailAddresses',
-            'isLocal',
-            'unixUserId',
-        ];
-        $this->validateRequired($mailDomain, 'create', $requiredAttributes);
+            'catch_all_forward_email_addresses',
+            'is_local',
+            'unix_user_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -109,18 +108,17 @@ class MailDomains extends Endpoint
      */
     public function update(MailDomain $mailDomain): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($mailDomain, 'update', [
             'domain',
-            'catchAllForwardEmailAddresses',
-            'unixUserId',
+            'catch_all_forward_email_addresses',
+            'unix_user_id',
             'id',
-            'clusterId'
-        ];
-        $this->validateRequired($mailDomain, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('mail-domains/%d', $mailDomain->id))
+            ->setUrl(sprintf('mail-domains/%d', $mailDomain->getId()))
             ->setBody($this->filterFields($mailDomain->toArray(), [
                 'domain',
                 'catch_all_forward_email_addresses',

--- a/src/Endpoints/SshKeys.php
+++ b/src/Endpoints/SshKeys.php
@@ -72,12 +72,11 @@ class SshKeys extends Endpoint
      */
     public function create(SshKey $sshKey): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($sshKey, 'create', [
             'name',
-            'publicKey',
-            'unixUserId',
-        ];
-        $this->validateRequired($sshKey, 'create', $requiredAttributes);
+            'public_key',
+            'unix_user_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -107,18 +106,17 @@ class SshKeys extends Endpoint
      */
     public function update(SshKey $sshKey): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($sshKey, 'update', [
             'name',
-            'publicKey',
-            'unixUserId',
+            'public_key',
+            'unix_user_id',
             'id',
-            'clusterId'
-        ];
-        $this->validateRequired($sshKey, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('ssh-keys/%d', $sshKey->id))
+            ->setUrl(sprintf('ssh-keys/%d', $sshKey->getId()))
             ->setBody($this->filterFields($sshKey->toArray(), [
                 'name',
                 'public_key',

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -110,13 +110,12 @@ class UnixUsers extends Endpoint
      */
     public function create(UnixUser $unixUser): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($unixUser, 'create', [
             'username',
             'password',
-            'defaultPhpVersion',
-            'clusterId',
-        ];
-        $this->validateRequired($unixUser, 'create', $requiredAttributes);
+            'default_php_version',
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -149,19 +148,18 @@ class UnixUsers extends Endpoint
      */
     public function update(UnixUser $unixUser): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($unixUser, 'update', [
             'username',
             'password',
-            'defaultPhpVersion',
+            'default_php_version',
             'id',
-            'clusterId',
-            'unixId',
-        ];
-        $this->validateRequired($unixUser, 'update', $requiredAttributes);
+            'cluster_id',
+            'unix_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('unix-users/%d', $unixUser->id))
+            ->setUrl(sprintf('unix-users/%d', $unixUser->getId()))
             ->setBody($this->filterFields($unixUser->toArray(), [
                 'username',
                 'password',

--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -72,16 +72,15 @@ class VirtualHosts extends Endpoint
      */
     public function create(VirtualHost $virtualHost): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($virtualHost, 'create', [
             'domain',
-            'serverAliases',
-            'unixUserId',
-            'documentRoot',
-            'publicRoot',
-            'forceSsl',
-            'balancerBackendName',
-        ];
-        $this->validateRequired($virtualHost, 'create', $requiredAttributes);
+            'server_aliases',
+            'unix_user_id',
+            'document_root',
+            'public_root',
+            'force_ssl',
+            'balancer_backend_name',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
@@ -118,22 +117,21 @@ class VirtualHosts extends Endpoint
      */
     public function update(VirtualHost $virtualHost): Response
     {
-        $requiredAttributes = [
+        $this->validateRequired($virtualHost, 'update', [
             'domain',
-            'serverAliases',
-            'unixUserId',
-            'documentRoot',
-            'publicRoot',
-            'forceSsl',
+            'server_aliases',
+            'unix_user_id',
+            'document_root',
+            'public_root',
+            'force_ssl',
+            'balancer_backend_name',
             'id',
-            'clusterId',
-            'balancerBackendName',
-        ];
-        $this->validateRequired($virtualHost, 'update', $requiredAttributes);
+            'cluster_id',
+        ]);
 
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('virtual-hosts/%d', $virtualHost->id))
+            ->setUrl(sprintf('virtual-hosts/%d', $virtualHost->getId()))
             ->setBody($this->filterFields($virtualHost->toArray(), [
                 'domain',
                 'server_aliases',

--- a/src/Enums/DatabaseEngine.php
+++ b/src/Enums/DatabaseEngine.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class DatabaseEngine
+{
+    public const SERVER_SOFTWARE_MARIADB = 'MariaDB';
+    public const SERVER_SOFTWARE_POSTGRES = 'PostgreSQL';
+
+    public const AVAILABLE_SERVER_SOFTWARE = [
+        self::SERVER_SOFTWARE_MARIADB,
+        self::SERVER_SOFTWARE_POSTGRES,
+    ];
+}

--- a/src/Exceptions/ClusterApiException.php
+++ b/src/Exceptions/ClusterApiException.php
@@ -15,4 +15,8 @@ class ClusterApiException extends Exception
     protected const REQUEST_INVALID = 201;
 
     protected const API_NOT_UP = 300;
+
+    protected const MODEL_PROPERTY_NOT_AVAILABLE = 400;
+
+    protected const VALIDATION_FAILED = 500;
 }

--- a/src/Exceptions/ModelException.php
+++ b/src/Exceptions/ModelException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Exceptions;
+
+use Throwable;
+
+class ModelException extends ClusterApiException
+{
+    public static function propertyNotAvailable(string $property, Throwable $previous = null): ModelException
+    {
+        return new self(
+            sprintf('The property `%s` is not available for this model', $property),
+            self::MODEL_PROPERTY_NOT_AVAILABLE,
+            $previous
+        );
+    }
+}

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Exceptions;
+
+use Throwable;
+
+class ValidationException extends ClusterApiException
+{
+    public static function validationFailed(array $failedValidations = [], Throwable $previous = null): ValidationException
+    {
+        return new self(
+            sprintf('The validation failed: `%s`', implode(', ', $failedValidations)),
+            self::VALIDATION_FAILED,
+            $previous
+        );
+    }
+}

--- a/src/Models/AccessLog.php
+++ b/src/Models/AccessLog.php
@@ -5,39 +5,122 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class AccessLog implements Model
+class AccessLog extends ClusterModel implements Model
 {
-    public string $remoteAddress;
-    public string $rawMessage;
-    public string $method;
-    public string $uri;
-    public string $timestamp;
-    public int $statusCode;
-    public int $bytesSent;
+    private string $remoteAddress;
+    private string $rawMessage;
+    private string $method;
+    private string $uri;
+    private string $timestamp;
+    private int $statusCode;
+    private int $bytesSent;
+
+    public function getRemoteAddress(): string
+    {
+        return $this->remoteAddress;
+    }
+
+    public function setRemoteAddress(string $remoteAddress): AccessLog
+    {
+        $this->remoteAddress = $remoteAddress;
+
+        return $this;
+    }
+
+    public function getRawMessage(): string
+    {
+        return $this->rawMessage;
+    }
+
+    public function setRawMessage(string $rawMessage): AccessLog
+    {
+        $this->rawMessage = $rawMessage;
+
+        return $this;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function setMethod(string $method): AccessLog
+    {
+        $this->method = $method;
+
+        return $this;
+    }
+
+    public function getUri(): string
+    {
+        return $this->uri;
+    }
+
+    public function setUri(string $uri): AccessLog
+    {
+        $this->uri = $uri;
+
+        return $this;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function setTimestamp(string $timestamp): AccessLog
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function setStatusCode(int $statusCode): AccessLog
+    {
+        $this->statusCode = $statusCode;
+
+        return $this;
+    }
+
+    public function getBytesSent(): int
+    {
+        return $this->bytesSent;
+    }
+
+    public function setBytesSent(int $bytesSent): AccessLog
+    {
+        $this->bytesSent = $bytesSent;
+
+        return $this;
+    }
 
     public function fromArray(array $data): AccessLog
     {
-        $accessLog = new self();
-        $accessLog->remoteAddress = Arr::get($data, 'remote_address');
-        $accessLog->rawMessage = Arr::get($data, 'raw_message');
-        $accessLog->method = Arr::get($data, 'method');
-        $accessLog->uri = Arr::get($data, 'uri');
-        $accessLog->timestamp = Arr::get($data, 'timestamp');
-        $accessLog->statusCode = Arr::get($data, 'status_code');
-        $accessLog->bytesSent = Arr::get($data, 'bytes_sent');
-        return $accessLog;
+        return $this
+            ->setRemoteAddress(Arr::get($data, 'remote_address'))
+            ->setRawMessage(Arr::get($data, 'raw_message'))
+            ->setMethod(Arr::get($data, 'method'))
+            ->setUri(Arr::get($data, 'uri'))
+            ->setTimestamp(Arr::get($data, 'timestamp'))
+            ->setStatusCode(Arr::get($data, 'status_code'))
+            ->setBytesSent(Arr::get($data, 'bytes_sent'));
     }
 
     public function toArray(): array
     {
         return [
-            'remote_address' => $this->remoteAddress,
-            'raw_message' => $this->rawMessage,
-            'method' => $this->method,
-            'uri' => $this->uri,
-            'timestamp' => $this->timestamp,
-            'status_code' => $this->statusCode,
-            'bytes_sent' => $this->bytesSent,
+            'remote_address' => $this->getRemoteAddress(),
+            'raw_message' => $this->getRawMessage(),
+            'method' => $this->getMethod(),
+            'uri' => $this->getUri(),
+            'timestamp' => $this->getTimestamp(),
+            'status_code' => $this->getStatusCode(),
+            'bytes_sent' => $this->getBytesSent(),
         ];
     }
 }

--- a/src/Models/Certificate.php
+++ b/src/Models/Certificate.php
@@ -5,45 +5,152 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Certificate implements Model
+class Certificate extends ClusterModel implements Model
 {
-    public array $commonNames = [];
-    public ?string $certificate = null;
-    public ?string $cachain = null;
-    public ?string $privateKey = null;
-    public ?int $id = null;
-    public ?string $statusMessage = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private array $commonNames = [];
+    private ?string $certificate = null;
+    private ?string $caChain = null;
+    private ?string $privateKey = null;
+    private ?int $id = null;
+    private ?string $statusMessage = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getCommonNames(): array
+    {
+        return $this->commonNames;
+    }
+
+    public function setCommonNames(array $commonNames): Certificate
+    {
+        $this->commonNames = $commonNames;
+
+        return $this;
+    }
+
+    public function getCertificate(): ?string
+    {
+        return $this->certificate;
+    }
+
+    public function setCertificate(?string $certificate): Certificate
+    {
+        $this->certificate = $certificate;
+
+        return $this;
+    }
+
+    public function getCaChain(): ?string
+    {
+        return $this->caChain;
+    }
+
+    public function setCaChain(?string $caChain): Certificate
+    {
+        $this->caChain = $caChain;
+
+        return $this;
+    }
+
+    public function getPrivateKey(): ?string
+    {
+        return $this->privateKey;
+    }
+
+    public function setPrivateKey(?string $privateKey): Certificate
+    {
+        $this->privateKey = $privateKey;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): Certificate
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getStatusMessage(): ?string
+    {
+        return $this->statusMessage;
+    }
+
+    public function setStatusMessage(?string $statusMessage): Certificate
+    {
+        $this->statusMessage = $statusMessage;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): Certificate
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): Certificate
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): Certificate
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Certificate
     {
-        $certificate = new self();
-        $certificate->commonNames = Arr::get($data, 'common_names', []);
-        $certificate->certificate = Arr::get($data, 'certificate');
-        $certificate->cachain = Arr::get($data, 'ca_chain');
-        $certificate->privateKey = Arr::get($data, 'private_key');
-        $certificate->id = Arr::get($data, 'id');
-        $certificate->statusMessage = Arr::get($data, 'status_message');
-        $certificate->clusterId = Arr::get($data, 'cluster_id');
-        $certificate->createdAt = Arr::get($data, 'created_at');
-        $certificate->updatedAt = Arr::get($data, 'updated_at');
-        return $certificate;
+        return $this
+            ->setCommonNames(Arr::get($data, 'common_names', []))
+            ->setCertificate(Arr::get($data, 'certificate'))
+            ->setCaChain(Arr::get($data, 'ca_chain'))
+            ->setPrivateKey(Arr::get($data, 'private_key'))
+            ->setId(Arr::get($data, 'id'))
+            ->setStatusMessage(Arr::get($data, 'status_message'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'common_names' => $this->commonNames,
-            'certificate' => $this->certificate,
-            'ca_chain' => $this->cachain,
-            'private_key' => $this->privateKey,
-            'id' => $this->id,
-            'status_message' => $this->statusMessage,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'common_names' => $this->getCommonNames(),
+            'certificate' => $this->getCertificate(),
+            'ca_chain' => $this->getCaChain(),
+            'private_key' => $this->getPrivateKey(),
+            'id' => $this->getId(),
+            'status_message' => $this->getStatusMessage(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -5,39 +5,212 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Cluster implements Model
+class Cluster extends ClusterModel implements Model
 {
-    public string $name = '';
-    public ?array $groups = [];
-    public ?string $unixUsersHomeDirectory = null;
-    public ?string $databasesDataDirectory = null;
-    public ?int $id = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $name = '';
+    private array $groups = [];
+    private ?string $unixUsersHomeDirectory = null;
+    private ?string $databasesDataDirectory = null;
+    private array $phpVersions = [];
+    private array $customPhpModulesNames = [];
+    private ?bool $phpIoncubeEnabled = null;
+    private ?string $customerId = null;
+    private ?bool $wordpressToolkitEnabled = null;
+    private ?bool $databaseToolkitEnabled = null;
+    private ?int $id = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): Cluster
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getGroups(): ?array
+    {
+        return $this->groups;
+    }
+
+    public function setGroups(array $groups): Cluster
+    {
+        $this->groups = $groups;
+
+        return $this;
+    }
+
+    public function getUnixUsersHomeDirectory(): ?string
+    {
+        return $this->unixUsersHomeDirectory;
+    }
+
+    public function setUnixUsersHomeDirectory(?string $unixUsersHomeDirectory): Cluster
+    {
+        $this->unixUsersHomeDirectory = $unixUsersHomeDirectory;
+
+        return $this;
+    }
+
+    public function getDatabasesDataDirectory(): ?string
+    {
+        return $this->databasesDataDirectory;
+    }
+
+    public function setDatabasesDataDirectory(?string $databasesDataDirectory): Cluster
+    {
+        $this->databasesDataDirectory = $databasesDataDirectory;
+
+        return $this;
+    }
+
+    public function getPhpVersions(): array
+    {
+        return $this->phpVersions;
+    }
+
+    public function setPhpVersions(array $phpVersions): Cluster
+    {
+        $this->phpVersions = $phpVersions;
+
+        return $this;
+    }
+
+    public function getCustomPhpModulesNames(): array
+    {
+        return $this->customPhpModulesNames;
+    }
+
+    public function setCustomPhpModulesNames(array $customPhpModulesNames): Cluster
+    {
+        $this->customPhpModulesNames = $customPhpModulesNames;
+
+        return $this;
+    }
+
+    public function isPhpIoncubeEnabled(): ?bool
+    {
+        return $this->phpIoncubeEnabled;
+    }
+
+    public function setPhpIoncubeEnabled(?bool $phpIoncubeEnabled): Cluster
+    {
+        $this->phpIoncubeEnabled = $phpIoncubeEnabled;
+
+        return $this;
+    }
+
+    public function getCustomerId(): ?string
+    {
+        return $this->customerId;
+    }
+
+    public function setCustomerId(?string $customerId): Cluster
+    {
+        $this->customerId = $customerId;
+
+        return $this;
+    }
+
+    public function isWordpressToolkitEnabled(): ?bool
+    {
+        return $this->wordpressToolkitEnabled;
+    }
+
+    public function setWordpressToolkitEnabled(?bool $wordpressToolkitEnabled): Cluster
+    {
+        $this->wordpressToolkitEnabled = $wordpressToolkitEnabled;
+
+        return $this;
+    }
+
+    public function isDatabaseToolkitEnabled(): ?bool
+    {
+        return $this->databaseToolkitEnabled;
+    }
+
+    public function setDatabaseToolkitEnabled(?bool $databaseToolkitEnabled): Cluster
+    {
+        $this->databaseToolkitEnabled = $databaseToolkitEnabled;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): Cluster
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): Cluster
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): Cluster
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Cluster
     {
-        $cluster = new self();
-        $cluster->name = Arr::get($data, 'name');
-        $cluster->groups = Arr::get($data, 'groups', []);
-        $cluster->unixUsersHomeDirectory = Arr::get($data, 'unix_users_home_directory');
-        $cluster->databasesDataDirectory = Arr::get($data, 'databases_data_directory');
-        $cluster->id = Arr::get($data, 'id');
-        $cluster->createdAt = Arr::get($data, 'created_at');
-        $cluster->updatedAt = Arr::get($data, 'updated_at');
-        return $cluster;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setGroups(Arr::get($data, 'groups', []))
+            ->setUnixUsersHomeDirectory(Arr::get($data, 'unix_users_home_directory'))
+            ->setDatabasesDataDirectory(Arr::get($data, 'databases_data_directory'))
+            ->setPhpVersions(Arr::get($data, 'php_versions', []))
+            ->setCustomPhpModulesNames(Arr::get($data, 'custom_php_modules_names', []))
+            ->setPhpIoncubeEnabled(Arr::get($data, 'php_ioncube_enabled'))
+            ->setCustomerId(Arr::get($data, 'customer_id'))
+            ->setWordpressToolkitEnabled(Arr::get($data, 'wordpress_toolkit_enabled'))
+            ->setDatabaseToolkitEnabled(Arr::get($data, 'database_toolkit_enabled'))
+            ->setId(Arr::get($data, 'id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'groups' => $this->groups,
-            'unix_users_home_directory' => $this->unixUsersHomeDirectory,
-            'databases_data_directory' => $this->databasesDataDirectory,
-            'id' => $this->id,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'groups' => $this->getGroups(),
+            'unix_users_home_directory' => $this->getUnixUsersHomeDirectory(),
+            'databases_data_directory' => $this->getDatabasesDataDirectory(),
+            'php_versions' => $this->getPhpVersions(),
+            'custom_php_modules_names' => $this->getCustomPhpModulesNames(),
+            'php_ioncube_enabled' => $this->isPhpIoncubeEnabled(),
+            'customer_id' => $this->getCustomerId(),
+            'wordpress_toolkit_enabled' => $this->isWordpressToolkitEnabled(),
+            'database_toolkit_enabled' => $this->isDatabaseToolkitEnabled(),
+            'id' => $this->getId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/ClusterModel.php
+++ b/src/Models/ClusterModel.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ModelException;
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ValidationException;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Str;
+
+abstract class ClusterModel
+{
+    /**
+     * Provide fallback to allow the user of properties but still using the getters and setters.
+     *
+     * @param string $name
+     * @return mixed
+     * @throws ModelException
+     */
+    public function __get(string $name)
+    {
+        $method = sprintf('get%s', Str::studly($name));
+        if (! method_exists($this, $method)) {
+            throw ModelException::propertyNotAvailable($name);
+        }
+
+        return $this->$method();
+    }
+
+    /**
+     * Provide fallback to allow the user of properties but still using the getters and setters.
+     *
+     * @param string $name
+     * @param $value
+     * @return void
+     * @throws ModelException
+     */
+    public function __set(string $name, $value): void
+    {
+        $method = sprintf('set%s', Str::studly($name));
+        if (! method_exists($this, $method)) {
+            throw ModelException::propertyNotAvailable($name);
+        }
+
+        $this->$method($value);
+    }
+
+    /**
+     * Performs the validation rule.
+     *
+     * @param mixed $value
+     * @param string $type
+     * @param mixed $setting
+     * @return bool
+     */
+    private function performValidation($value, string $type, $setting): bool
+    {
+        switch ($type) {
+            case 'length_max':
+                return is_string($value) && Str::length($value) <= $setting;
+            case 'pattern':
+                return is_string($value) && Str::match($value, sprintf('/%s/', $setting));
+            case 'in':
+                return in_array($value, $setting);
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Validate the provided value to the provided validations.
+     *
+     * @param mixed $value
+     * @param array $validations
+     * @throws ValidationException
+     */
+    protected function validate($value, array $validations = []): void
+    {
+        $failedValidations = [];
+        foreach ($validations as $type => $setting) {
+            if (! $this->performValidation($value, $type, $setting)) {
+                $failedValidations[] = sprintf(
+                    '%s: %s',
+                    $type,
+                    is_array($setting)
+                        ? implode(';', $setting)
+                        : $setting
+                );
+            }
+        }
+
+        if (count($failedValidations) !== 0) {
+            throw ValidationException::validationFailed($failedValidations);
+        }
+    }
+}

--- a/src/Models/Cms.php
+++ b/src/Models/Cms.php
@@ -5,36 +5,107 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Cms implements Model
+class Cms extends ClusterModel implements Model
 {
-    public string $name;
-    public int $virtualHostId;
-    public int $id;
-    public int $clusterId;
-    public string $createdAt;
-    public string $updatedAt;
+    private string $name;
+    private int $virtualHostId;
+    private int $id;
+    private int $clusterId;
+    private string $createdAt;
+    private string $updatedAt;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): Cms
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getVirtualHostId(): int
+    {
+        return $this->virtualHostId;
+    }
+
+    public function setVirtualHostId(int $virtualHostId): Cms
+    {
+        $this->virtualHostId = $virtualHostId;
+
+        return $this;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): Cms
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(int $clusterId): Cms
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(string $createdAt): Cms
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(string $updatedAt): Cms
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Cms
     {
-        $cms = new self();
-        $cms->name = Arr::get($data, 'name');
-        $cms->virtualHostId = Arr::get($data, 'virtual_host_id');
-        $cms->id = Arr::get($data, 'id');
-        $cms->clusterId = Arr::get($data, 'cluster_id');
-        $cms->createdAt = Arr::get($data, 'created_at');
-        $cms->updatedAt = Arr::get($data, 'updated_at');
-        return $cms;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setVirtualHostId(Arr::get($data, 'virtual_host_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'virtual_host_id' => $this->virtualHostId,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'virtual_host_id' => $this->getVirtualHostId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/Command.php
+++ b/src/Models/Command.php
@@ -5,45 +5,152 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Command implements Model
+class Command extends ClusterModel implements Model
 {
-    public string $command;
-    public array $secretValues = [];
-    public ?int $virtualHostId;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?int $returnCode = null;
-    public ?string $standardOut = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $command;
+    private array $secretValues = [];
+    private ?int $virtualHostId;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?int $returnCode = null;
+    private ?string $standardOut = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getCommand(): string
+    {
+        return $this->command;
+    }
+
+    public function setCommand(string $command): Command
+    {
+        $this->command = $command;
+
+        return $this;
+    }
+
+    public function getSecretValues(): array
+    {
+        return $this->secretValues;
+    }
+
+    public function setSecretValues(array $secretValues): Command
+    {
+        $this->secretValues = $secretValues;
+
+        return $this;
+    }
+
+    public function getVirtualHostId(): ?int
+    {
+        return $this->virtualHostId;
+    }
+
+    public function setVirtualHostId(?int $virtualHostId): Command
+    {
+        $this->virtualHostId = $virtualHostId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): Command
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): Command
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getReturnCode(): ?int
+    {
+        return $this->returnCode;
+    }
+
+    public function setReturnCode(?int $returnCode): Command
+    {
+        $this->returnCode = $returnCode;
+
+        return $this;
+    }
+
+    public function getStandardOut(): ?string
+    {
+        return $this->standardOut;
+    }
+
+    public function setStandardOut(?string $standardOut): Command
+    {
+        $this->standardOut = $standardOut;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): Command
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): Command
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Command
     {
-        $command = new self();
-        $command->command = Arr::get($data, 'command');
-        $command->secretValues = Arr::get($data, 'secret_values', []);
-        $command->virtualHostId = Arr::get($data, 'virtual_host_id');
-        $command->id = Arr::get($data, 'id');
-        $command->clusterId = Arr::get($data, 'cluster_id');
-        $command->returnCode = Arr::get($data, 'return_code');
-        $command->standardOut = Arr::get($data, 'standard_out');
-        $command->createdAt = Arr::get($data, 'created_at');
-        $command->updatedAt = Arr::get($data, 'updated_at');
-        return $command;
+        return $this
+            ->setCommand(Arr::get($data, 'command'))
+            ->setSecretValues(Arr::get($data, 'secret_values', []))
+            ->setVirtualHostId(Arr::get($data, 'virtual_host_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setReturnCode(Arr::get($data, 'return_code'))
+            ->setStandardOut(Arr::get($data, 'standard_out'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'command' => $this->command,
-            'secret_values' => $this->secretValues,
-            'virtual_host_id' => $this->virtualHostId,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'return_code' => $this->returnCode,
-            'standard_out' => $this->standardOut,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'command' => $this->getCommand(),
+            'secret_values' => $this->getSecretValues(),
+            'virtual_host_id' => $this->getVirtualHostId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'return_code' => $this->getReturnCode(),
+            'standard_out' => $this->getStandardOut(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -5,48 +5,172 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Cron implements Model
+class Cron extends ClusterModel implements Model
 {
-    public string $name;
-    public string $command;
-    public string $emailAddress;
-    public string $schedule;
-    public int $unixUserId;
-    public int $errorCount = 1;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $name;
+    private string $command;
+    private string $emailAddress;
+    private string $schedule;
+    private int $unixUserId;
+    private int $errorCount = 1;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): Cron
+    {
+        $this->validate($name, [
+            'length_max' => 64,
+            'pattern' => '^[a-z0-9-_.]+$',
+        ]);
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getCommand(): string
+    {
+        return $this->command;
+    }
+
+    public function setCommand(string $command): Cron
+    {
+        $this->command = $command;
+
+        return $this;
+    }
+
+    public function getEmailAddress(): string
+    {
+        return $this->emailAddress;
+    }
+
+    public function setEmailAddress(string $emailAddress): Cron
+    {
+        $this->emailAddress = $emailAddress;
+
+        return $this;
+    }
+
+    public function getSchedule(): string
+    {
+        return $this->schedule;
+    }
+
+    public function setSchedule(string $schedule): Cron
+    {
+        $this->schedule = $schedule;
+
+        return $this;
+    }
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): Cron
+    {
+        $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getErrorCount(): int
+    {
+        return $this->errorCount;
+    }
+
+    public function setErrorCount(int $errorCount): Cron
+    {
+        $this->errorCount = $errorCount;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): Cron
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): Cron
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): Cron
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): Cron
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Cron
     {
-        $cron = new self();
-        $cron->name = Arr::get($data, 'name');
-        $cron->command = Arr::get($data, 'command');
-        $cron->emailAddress = Arr::get($data, 'email_address');
-        $cron->schedule = Arr::get($data, 'schedule');
-        $cron->unixUserId = Arr::get($data, 'unix_user_id');
-        $cron->errorCount = Arr::get($data, 'error_count');
-        $cron->id = Arr::get($data, 'id');
-        $cron->clusterId = Arr::get($data, 'cluster_id');
-        $cron->createdAt = Arr::get($data, 'created_at');
-        $cron->updatedAt = Arr::get($data, 'updated_at');
-        return $cron;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setCommand(Arr::get($data, 'command'))
+            ->setEmailAddress(Arr::get($data, 'email_address'))
+            ->setSchedule(Arr::get($data, 'schedule'))
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setErrorCount(Arr::get($data, 'error_count'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'command' => $this->command,
-            'email_address' => $this->emailAddress,
-            'schedule' => $this->schedule,
-            'unix_user_id' => $this->unixUserId,
-            'error_count' => $this->errorCount,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'command' => $this->getCommand(),
+            'email_address' => $this->getEmailAddress(),
+            'schedule' => $this->getSchedule(),
+            'unix_user_id' => $this->getUnixUserId(),
+            'error_count' => $this->getErrorCount(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/Database.php
+++ b/src/Models/Database.php
@@ -4,46 +4,122 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\DatabaseEngine;
 
-class Database implements Model
+class Database extends ClusterModel implements Model
 {
-    public const SERVER_SOFTWARE_MARIADB = 'MariaDB';
-    public const SERVER_SOFTWARE_POSTGRES = 'PostgreSQL';
+    private string $name;
+    private string $serverSoftwareName = DatabaseEngine::SERVER_SOFTWARE_MARIADB;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
 
-    public const DEFAULT_SERVER_SOFTWARE = self::SERVER_SOFTWARE_MARIADB;
+    public function getName(): string
+    {
+        return $this->name;
+    }
 
-    public string $name;
-    public string $serverSoftwareName = self::DEFAULT_SERVER_SOFTWARE;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    public function setName(string $name): Database
+    {
+        $this->validate($name, [
+            'length_max' => 63,
+            'pattern' => '^[a-zA-Z0-9-_]+$',
+        ]);
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getServerSoftwareName(): string
+    {
+        return $this->serverSoftwareName;
+    }
+
+    public function setServerSoftwareName(string $serverSoftwareName): Database
+    {
+        $this->validate($serverSoftwareName, [
+            'in' => DatabaseEngine::AVAILABLE_SERVER_SOFTWARE,
+        ]);
+
+        $this->serverSoftwareName = $serverSoftwareName;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): Database
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): Database
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): Database
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): Database
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Database
     {
-        $database = new self();
-        $database->name = Arr::get($data, 'name');
-        $database->serverSoftwareName = Arr::get(
-            $data,
-            'server_software_name',
-            self::DEFAULT_SERVER_SOFTWARE
-        );
-        $database->id = Arr::get($data, 'id');
-        $database->clusterId = Arr::get($data, 'cluster_id');
-        $database->createdAt = Arr::get($data, 'created_at');
-        $database->updatedAt = Arr::get($data, 'updated_at');
-        return $database;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setServerSoftwareName(Arr::get(
+                $data,
+                'server_software_name',
+                DatabaseEngine::SERVER_SOFTWARE_MARIADB
+            ))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'server_software_name' => $this->serverSoftwareName,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'server_software_name' => $this->getServerSoftwareName(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/DatabaseUsage.php
+++ b/src/Models/DatabaseUsage.php
@@ -5,27 +5,62 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class DatabaseUsage implements Model
+class DatabaseUsage extends ClusterModel implements Model
 {
-    public int $databaseId;
-    public int $usage;
-    public string $timestamp;
+    private int $databaseId;
+    private int $usage;
+    private string $timestamp;
+
+    public function getDatabaseId(): int
+    {
+        return $this->databaseId;
+    }
+
+    public function setDatabaseId(int $databaseId): DatabaseUsage
+    {
+        $this->databaseId = $databaseId;
+
+        return $this;
+    }
+
+    public function getUsage(): int
+    {
+        return $this->usage;
+    }
+
+    public function setUsage(int $usage): DatabaseUsage
+    {
+        $this->usage = $usage;
+
+        return $this;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function setTimestamp(string $timestamp): DatabaseUsage
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
 
     public function fromArray(array $data): DatabaseUsage
     {
-        $databaseUsage = new self();
-        $databaseUsage->databaseId = Arr::get($data, 'database_id');
-        $databaseUsage->usage = Arr::get($data, 'usage');
-        $databaseUsage->timestamp = Arr::get($data, 'timestamp');
-        return $databaseUsage;
+        return $this
+            ->setDatabaseId(Arr::get($data, 'database_id'))
+            ->setUsage(Arr::get($data, 'usage'))
+            ->setTimestamp(Arr::get($data, 'timestamp'));
     }
 
     public function toArray(): array
     {
         return [
-            'database_id' => $this->databaseId,
-            'usage' => $this->usage,
-            'timestamp' => $this->timestamp,
+            'database_id' => $this->getDatabaseId(),
+            'usage' => $this->getUsage(),
+            'timestamp' => $this->getTimestamp(),
         ];
     }
 }

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -4,48 +4,156 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\DatabaseEngine;
 
-class DatabaseUser implements Model
+class DatabaseUser extends ClusterModel implements Model
 {
     private const DEFAULT_HOST = '%';
 
-    public string $name;
-    public string $host = self::DEFAULT_HOST;
-    public string $password = '';
-    public string $serverSoftwareName = Database::DEFAULT_SERVER_SOFTWARE;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $name;
+    private string $host = self::DEFAULT_HOST;
+    private string $password = '';
+    private string $serverSoftwareName = DatabaseEngine::SERVER_SOFTWARE_MARIADB;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): DatabaseUser
+    {
+        $this->validate($name, [
+            'length_max' => 63,
+        ]);
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    public function setHost(string $host): DatabaseUser
+    {
+        $this->validate($host, [
+            'length_max' => 253,
+        ]);
+
+        $this->host = $host;
+
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): DatabaseUser
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getServerSoftwareName(): string
+    {
+        return $this->serverSoftwareName;
+    }
+
+    public function setServerSoftwareName(string $serverSoftwareName): DatabaseUser
+    {
+        $this->validate($serverSoftwareName, [
+            'in' => DatabaseEngine::AVAILABLE_SERVER_SOFTWARE,
+        ]);
+
+        $this->serverSoftwareName = $serverSoftwareName;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): DatabaseUser
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): DatabaseUser
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): DatabaseUser
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): DatabaseUser
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): DatabaseUser
     {
-        $databaseUser = new self();
-        $databaseUser->name = Arr::get($data, 'name');
-        $databaseUser->id = Arr::get($data, 'id');
-        $databaseUser->host = Arr::get($data, 'host', self::DEFAULT_HOST);
-        $databaseUser->serverSoftwareName = Arr::get(
-            $data,
-            'server_software_name',
-            Database::DEFAULT_SERVER_SOFTWARE
-        );
-        $databaseUser->clusterId = Arr::get($data, 'cluster_id');
-        $databaseUser->createdAt = Arr::get($data, 'created_at');
-        $databaseUser->updatedAt = Arr::get($data, 'updated_at');
-        return $databaseUser;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setId(Arr::get($data, 'id'))
+            ->setHost(Arr::get($data, 'host', self::DEFAULT_HOST))
+            ->setServerSoftwareName(Arr::get(
+                $data,
+                'server_software_name',
+                DatabaseEngine::SERVER_SOFTWARE_MARIADB
+            ))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'host' => $this->host,
-            'password' => $this->password,
-            'server_software_name' => $this->serverSoftwareName,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'host' => $this->getHost(),
+            'password' => $this->getPassword(),
+            'server_software_name' => $this->getServerSoftwareName(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/DatabaseUserGrant.php
+++ b/src/Models/DatabaseUserGrant.php
@@ -5,45 +5,145 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class DatabaseUserGrant implements Model
+class DatabaseUserGrant extends ClusterModel implements Model
 {
     public const DEFAULT_TABLE_NAME = '*';
     public const DEFAULT_PRIVILEGE_NAME = 'ALL';
 
-    public int $databaseId;
-    public int $databaseUserId;
-    public string $tableName = self::DEFAULT_TABLE_NAME;
-    public string $privilegeName = self::DEFAULT_PRIVILEGE_NAME;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private int $databaseId;
+    private int $databaseUserId;
+    private string $tableName = self::DEFAULT_TABLE_NAME;
+    private string $privilegeName = self::DEFAULT_PRIVILEGE_NAME;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getDatabaseId(): int
+    {
+        return $this->databaseId;
+    }
+
+    public function setDatabaseId(int $databaseId): DatabaseUserGrant
+    {
+        $this->databaseId = $databaseId;
+
+        return $this;
+    }
+
+    public function getDatabaseUserId(): int
+    {
+        return $this->databaseUserId;
+    }
+
+    public function setDatabaseUserId(int $databaseUserId): DatabaseUserGrant
+    {
+        $this->databaseUserId = $databaseUserId;
+
+        return $this;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+
+    public function setTableName(string $tableName): DatabaseUserGrant
+    {
+        $this->validate($tableName, [
+            'length_max' => 64,
+            'pattern' => '^[a-z0-9-_]+$',
+        ]);
+
+        $this->tableName = $tableName;
+
+        return $this;
+    }
+
+    public function getPrivilegeName(): string
+    {
+        return $this->privilegeName;
+    }
+
+    public function setPrivilegeName(string $privilegeName): DatabaseUserGrant
+    {
+        $this->privilegeName = $privilegeName;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): DatabaseUserGrant
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): DatabaseUserGrant
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): DatabaseUserGrant
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): DatabaseUserGrant
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): DatabaseUserGrant
     {
-        $databaseUserGrant = new self();
-        $databaseUserGrant->databaseId = Arr::get($data, 'database_id');
-        $databaseUserGrant->databaseUserId = Arr::get($data, 'database_user_id');
-        $databaseUserGrant->tableName = Arr::get($data, 'table_name', self::DEFAULT_TABLE_NAME);
-        $databaseUserGrant->privilegeName = Arr::get($data,'privilege_name',self::DEFAULT_PRIVILEGE_NAME);
-        $databaseUserGrant->id = Arr::get($data, 'id');
-        $databaseUserGrant->clusterId = Arr::get($data, 'cluster_id');
-        $databaseUserGrant->createdAt = Arr::get($data, 'created_at');
-        $databaseUserGrant->updatedAt = Arr::get($data, 'updated_at');
-        return $databaseUserGrant;
+        return $this
+            ->setDatabaseId(Arr::get($data, 'database_id'))
+            ->setDatabaseUserId(Arr::get($data, 'database_user_id'))
+            ->setTableName(Arr::get($data, 'table_name', self::DEFAULT_TABLE_NAME))
+            ->setPrivilegeName(Arr::get($data,'privilege_name',self::DEFAULT_PRIVILEGE_NAME))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'database_id' => $this->databaseId,
-            'database_user_id' => $this->databaseUserId,
-            'table_name' => $this->tableName,
-            'privilege_name' => $this->privilegeName,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'database_id' => $this->getDatabaseId(),
+            'database_user_id' => $this->getDatabaseUserId(),
+            'table_name' => $this->getTableName(),
+            'privilege_name' => $this->getPrivilegeName(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/DetailMessage.php
+++ b/src/Models/DetailMessage.php
@@ -5,21 +5,31 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class DetailMessage implements Model
+class DetailMessage extends ClusterModel implements Model
 {
-    public string $detail;
+    private string $detail;
+
+    public function getDetail(): string
+    {
+        return $this->detail;
+    }
+
+    public function setDetail(string $detail): DetailMessage
+    {
+        $this->detail = $detail;
+
+        return $this;
+    }
 
     public function fromArray(array $data): DetailMessage
     {
-        $detailMessage = new self();
-        $detailMessage->detail = Arr::get($data, 'detail', '');
-        return $detailMessage;
+        return $this->setDetail(Arr::get($data, 'detail', ''));
     }
 
     public function toArray(): array
     {
         return [
-            'detail' => $this->detail,
+            'detail' => $this->getDetail(),
         ];
     }
 }

--- a/src/Models/ErrorLog.php
+++ b/src/Models/ErrorLog.php
@@ -5,36 +5,107 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class ErrorLog implements Model
+class ErrorLog extends ClusterModel implements Model
 {
-    public string $remoteAddress;
-    public string $rawMessage;
-    public string $method;
-    public string $uri;
-    public string $timestamp;
-    public string $errorMessage;
+    private string $remoteAddress;
+    private string $rawMessage;
+    private string $method;
+    private string $uri;
+    private string $timestamp;
+    private string $errorMessage;
+
+    public function getRemoteAddress(): string
+    {
+        return $this->remoteAddress;
+    }
+
+    public function setRemoteAddress(string $remoteAddress): ErrorLog
+    {
+        $this->remoteAddress = $remoteAddress;
+
+        return $this;
+    }
+
+    public function getRawMessage(): string
+    {
+        return $this->rawMessage;
+    }
+
+    public function setRawMessage(string $rawMessage): ErrorLog
+    {
+        $this->rawMessage = $rawMessage;
+
+        return $this;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function setMethod(string $method): ErrorLog
+    {
+        $this->method = $method;
+
+        return $this;
+    }
+
+    public function getUri(): string
+    {
+        return $this->uri;
+    }
+
+    public function setUri(string $uri): ErrorLog
+    {
+        $this->uri = $uri;
+
+        return $this;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function setTimestamp(string $timestamp): ErrorLog
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
+
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+
+    public function setErrorMessage(string $errorMessage): ErrorLog
+    {
+        $this->errorMessage = $errorMessage;
+
+        return $this;
+    }
 
     public function fromArray(array $data): ErrorLog
     {
-        $errorLog = new self();
-        $errorLog->remoteAddress = Arr::get($data, 'remote_address');
-        $errorLog->rawMessage = Arr::get($data, 'raw_message');
-        $errorLog->method = Arr::get($data, 'method');
-        $errorLog->uri = Arr::get($data, 'uri');
-        $errorLog->timestamp = Arr::get($data, 'timestamp');
-        $errorLog->errorMessage = Arr::get($data, 'error_message');
-        return $errorLog;
+        return $this
+            ->setRemoteAddress(Arr::get($data, 'remote_address'))
+            ->setRawMessage(Arr::get($data, 'raw_message'))
+            ->setMethod(Arr::get($data, 'method'))
+            ->setUri(Arr::get($data, 'uri'))
+            ->setTimestamp(Arr::get($data, 'timestamp'))
+            ->setErrorMessage(Arr::get($data, 'error_message'));
     }
 
     public function toArray(): array
     {
         return [
-            'remote_address' => $this->remoteAddress,
-            'raw_message' => $this->rawMessage,
-            'method' => $this->method,
-            'uri' => $this->uri,
-            'timestamp' => $this->timestamp,
-            'error_message' => $this->errorMessage,
+            'remote_address' => $this->getRemoteAddress(),
+            'raw_message' => $this->getRawMessage(),
+            'method' => $this->getMethod(),
+            'uri' => $this->getUri(),
+            'timestamp' => $this->getTimestamp(),
+            'error_message' => $this->getErrorMessage(),
         ];
     }
 }

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -5,51 +5,187 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class FpmPool implements Model
+class FpmPool extends ClusterModel implements Model
 {
-    public string $name;
-    public int $unixUserId;
-    public string $version;
-    public int $maxChildren;
-    public int $maxRequests = 1000;
-    public int $processIdleTimeout = 600;
-    public ?int $cpuLimit = null;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $name;
+    private int $unixUserId;
+    private string $version;
+    private int $maxChildren;
+    private int $maxRequests = 1000;
+    private int $processIdleTimeout = 600;
+    private ?int $cpuLimit = null;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): FpmPool
+    {
+        $this->validate($name, [
+            'length_max' => 64,
+            'pattern' => '^[a-z0-9-_]+$',
+        ]);
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): FpmPool
+    {
+        $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function setVersion(string $version): FpmPool
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function getMaxChildren(): int
+    {
+        return $this->maxChildren;
+    }
+
+    public function setMaxChildren(int $maxChildren): FpmPool
+    {
+        $this->maxChildren = $maxChildren;
+
+        return $this;
+    }
+
+    public function getMaxRequests(): int
+    {
+        return $this->maxRequests;
+    }
+
+    public function setMaxRequests(int $maxRequests): FpmPool
+    {
+        $this->maxRequests = $maxRequests;
+
+        return $this;
+    }
+
+    public function getProcessIdleTimeout(): int
+    {
+        return $this->processIdleTimeout;
+    }
+
+    public function setProcessIdleTimeout(int $processIdleTimeout): FpmPool
+    {
+        $this->processIdleTimeout = $processIdleTimeout;
+
+        return $this;
+    }
+
+    public function getCpuLimit(): ?int
+    {
+        return $this->cpuLimit;
+    }
+
+    public function setCpuLimit(?int $cpuLimit): FpmPool
+    {
+        $this->cpuLimit = $cpuLimit;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): FpmPool
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): FpmPool
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): FpmPool
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): FpmPool
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): FpmPool
     {
-        $fpmPool = new FpmPool();
-        $fpmPool->name = Arr::get($data, 'name');
-        $fpmPool->unixUserId = Arr::get($data, 'unix_user_id');
-        $fpmPool->version = Arr::get($data, 'version');
-        $fpmPool->maxChildren = Arr::get($data, 'max_children');
-        $fpmPool->maxRequests = Arr::get($data, 'max_requests');
-        $fpmPool->processIdleTimeout = Arr::get($data, 'process_idle_timeout');
-        $fpmPool->cpuLimit = Arr::get($data, 'cpu_limit');
-        $fpmPool->id = Arr::get($data, 'id');
-        $fpmPool->clusterId = Arr::get($data, 'cluster_id');
-        $fpmPool->createdAt = Arr::get($data, 'created_at');
-        $fpmPool->updatedAt = Arr::get($data, 'updated_at');
-        return $fpmPool;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setVersion(Arr::get($data, 'version'))
+            ->setMaxChildren(Arr::get($data, 'max_children'))
+            ->setMaxRequests(Arr::get($data, 'max_requests'))
+            ->setProcessIdleTimeout(Arr::get($data, 'process_idle_timeout'))
+            ->setCpuLimit(Arr::get($data, 'cpu_limit'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'unix_user_id' => $this->unixUserId,
-            'version' => $this->version,
-            'max_children' => $this->maxChildren,
-            'max_requests' => $this->maxRequests,
-            'process_idle_timeout' => $this->processIdleTimeout,
-            'cpu_limit' => $this->cpuLimit,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'unix_user_id' => $this->getUnixUserId(),
+            'version' => $this->getVersion(),
+            'max_children' => $this->getMaxChildren(),
+            'max_requests' => $this->getMaxRequests(),
+            'process_idle_timeout' => $this->getProcessIdleTimeout(),
+            'cpu_limit' => $this->getCpuLimit(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/Health.php
+++ b/src/Models/Health.php
@@ -6,26 +6,36 @@ use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\HealthStatus;
 
-class Health implements Model
+class Health extends ClusterModel implements Model
 {
-    public string $status;
+    private string $status;
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): Health
+    {
+        $this->status = $status;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Health
     {
-        $health = new self();
-        $health->status = Arr::get($data, 'status');
-        return $health;
-    }
-
-    public function isUp(): bool
-    {
-        return $this->status === HealthStatus::UP;
+        return $this->setStatus(Arr::get($data, 'status'));
     }
 
     public function toArray(): array
     {
         return [
-            'status' => $this->status,
+            'status' => $this->getStatus(),
         ];
+    }
+
+    public function isUp(): bool
+    {
+        return $this->getStatus() === HealthStatus::UP;
     }
 }

--- a/src/Models/HttpValidationError.php
+++ b/src/Models/HttpValidationError.php
@@ -5,26 +5,36 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class HttpValidationError implements Model
+class HttpValidationError extends ClusterModel implements Model
 {
-    public array $detail = [];
+    private array $detail = [];
+
+    public function getDetail(): array
+    {
+        return $this->detail;
+    }
+
+    public function setDetail(array $detail): HttpValidationError
+    {
+        $this->detail = $detail;
+
+        return $this;
+    }
 
     public function fromArray(array $data): HttpValidationError
     {
-        $httpValidationError = new self();
-        $httpValidationError->detail = array_map(
+        return $this->setDetail(array_map(
             function (array $detail) {
                 return (new ValidationError())->fromArray($detail);
             },
             Arr::get($data, 'detail', [])
-        );
-        return $httpValidationError;
+        ));
     }
 
     public function toArray(): array
     {
         return [
-            'detail' => $this->detail,
+            'detail' => $this->getDetail(),
         ];
     }
 }

--- a/src/Models/Login.php
+++ b/src/Models/Login.php
@@ -4,24 +4,96 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Login implements Model
+class Login extends ClusterModel implements Model
 {
-    public ?string $grantType = null;
-    public string $username;
-    public string $password;
-    public string $scope = '';
-    public ?string $clientId = null;
-    public ?string $clientSecret = null;
+    private ?string $grantType = null;
+    private string $username;
+    private string $password;
+    private string $scope = '';
+    private ?string $clientId = null;
+    private ?string $clientSecret = null;
+
+    public function getGrantType(): ?string
+    {
+        return $this->grantType;
+    }
+
+    public function setGrantType(?string $grantType): Login
+    {
+        $this->grantType = $grantType;
+
+        return $this;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(string $username): Login
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): Login
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getScope(): string
+    {
+        return $this->scope;
+    }
+
+    public function setScope(string $scope): Login
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function getClientId(): ?string
+    {
+        return $this->clientId;
+    }
+
+    public function setClientId(?string $clientId): Login
+    {
+        $this->clientId = $clientId;
+
+        return $this;
+    }
+
+    public function getClientSecret(): ?string
+    {
+        return $this->clientSecret;
+    }
+
+    public function setClientSecret(?string $clientSecret): Login
+    {
+        $this->clientSecret = $clientSecret;
+
+        return $this;
+    }
 
     public function toArray(): array
     {
         return [
-            'grant_type' => $this->grantType,
-            'username' => $this->username,
-            'password' => $this->password,
-            'scope' => $this->scope,
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret,
+            'grant_type' => $this->getGrantType(),
+            'username' => $this->getUsername(),
+            'password' => $this->getPassword(),
+            'scope' => $this->getScope(),
+            'client_id' => $this->getClientId(),
+            'client_secret' => $this->getClientSecret(),
         ];
     }
 }

--- a/src/Models/MailAccount.php
+++ b/src/Models/MailAccount.php
@@ -5,42 +5,141 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class MailAccount implements Model
+class MailAccount extends ClusterModel implements Model
 {
-    public string $localPart;
-    public string $password;
-    public ?int $quota = null;
-    public int $mailDomainId;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $localPart;
+    private string $password;
+    private ?int $quota = null;
+    private int $mailDomainId;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getLocalPart(): string
+    {
+        return $this->localPart;
+    }
+
+    public function setLocalPart(string $localPart): MailAccount
+    {
+        $this->validate($localPart, [
+            'length_max' => 64,
+        ]);
+
+        $this->localPart = $localPart;
+
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): MailAccount
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getQuota(): ?int
+    {
+        return $this->quota;
+    }
+
+    public function setQuota(?int $quota): MailAccount
+    {
+        $this->quota = $quota;
+
+        return $this;
+    }
+
+    public function getMailDomainId(): int
+    {
+        return $this->mailDomainId;
+    }
+
+    public function setMailDomainId(int $mailDomainId): MailAccount
+    {
+        $this->mailDomainId = $mailDomainId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): MailAccount
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): MailAccount
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): MailAccount
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): MailAccount
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): MailAccount
     {
-        $mailAccount = new self();
-        $mailAccount->localPart = Arr::get($data, 'local_part');
-        $mailAccount->password = Arr::get($data, 'password');
-        $mailAccount->quota = Arr::get($data, 'quota');
-        $mailAccount->mailDomainId = Arr::get($data, 'mail_domain_id');
-        $mailAccount->id = Arr::get($data, 'id');
-        $mailAccount->clusterId = Arr::get($data, 'cluster_id');
-        $mailAccount->createdAt = Arr::get($data, 'created_at');
-        $mailAccount->updatedAt = Arr::get($data, 'updated_at');
-        return $mailAccount;
+        return $this
+            ->setLocalPart(Arr::get($data, 'local_part'))
+            ->setPassword(Arr::get($data, 'password'))
+            ->setQuota(Arr::get($data, 'quota'))
+            ->setMailDomainId(Arr::get($data, 'mail_domain_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'local_part' => $this->localPart,
-            'password' => $this->password,
-            'quota' => $this->quota,
-            'mail_domain_id' => $this->mailDomainId,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'local_part' => $this->getLocalPart(),
+            'password' => $this->getPassword(),
+            'quota' => $this->getQuota(),
+            'mail_domain_id' => $this->getMailDomainId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/MailAccountUsage.php
+++ b/src/Models/MailAccountUsage.php
@@ -5,27 +5,62 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class MailAccountUsage implements Model
+class MailAccountUsage extends ClusterModel implements Model
 {
-    public int $mailAccountId;
-    public int $usage;
-    public string $timestamp;
+    private int $mailAccountId;
+    private int $usage;
+    private string $timestamp;
+
+    public function getMailAccountId(): int
+    {
+        return $this->mailAccountId;
+    }
+
+    public function setMailAccountId(int $mailAccountId): MailAccountUsage
+    {
+        $this->mailAccountId = $mailAccountId;
+
+        return $this;
+    }
+
+    public function getUsage(): int
+    {
+        return $this->usage;
+    }
+
+    public function setUsage(int $usage): MailAccountUsage
+    {
+        $this->usage = $usage;
+
+        return $this;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function setTimestamp(string $timestamp): MailAccountUsage
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
 
     public function fromArray(array $data): MailAccountUsage
     {
-        $mailAccountUsage = new self();
-        $mailAccountUsage->mailAccountId = Arr::get($data, 'mail_account_id');
-        $mailAccountUsage->usage = Arr::get($data, 'usage');
-        $mailAccountUsage->timestamp = Arr::get($data, 'timestamp');
-        return $mailAccountUsage;
+        return $this
+            ->setMailAccountId(Arr::get($data, 'mail_account_id'))
+            ->setUsage(Arr::get($data, 'usage'))
+            ->setTimestamp(Arr::get($data, 'timestamp'));
     }
 
     public function toArray(): array
     {
         return [
-            'mail_account_id' => $this->mailAccountId,
-            'usage' => $this->usage,
-            'timestamp' => $this->timestamp,
+            'mail_account_id' => $this->getMailAccountId(),
+            'usage' => $this->getUsage(),
+            'timestamp' => $this->getTimestamp(),
         ];
     }
 }

--- a/src/Models/MailAlias.php
+++ b/src/Models/MailAlias.php
@@ -5,39 +5,126 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class MailAlias implements Model
+class MailAlias extends ClusterModel implements Model
 {
-    public string $localPart;
-    public array $forwardEmailAddresses = [];
-    public ?int $mailDomainId = null;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $localPart;
+    private array $forwardEmailAddresses = [];
+    private ?int $mailDomainId = null;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getLocalPart(): string
+    {
+        return $this->localPart;
+    }
+
+    public function setLocalPart(string $localPart): MailAlias
+    {
+        $this->validate($localPart, [
+            'length_max' => 64,
+        ]);
+
+        $this->localPart = $localPart;
+
+        return $this;
+    }
+
+    public function getForwardEmailAddresses(): array
+    {
+        return $this->forwardEmailAddresses;
+    }
+
+    public function setForwardEmailAddresses(array $forwardEmailAddresses): MailAlias
+    {
+        $this->forwardEmailAddresses = $forwardEmailAddresses;
+
+        return $this;
+    }
+
+    public function getMailDomainId(): ?int
+    {
+        return $this->mailDomainId;
+    }
+
+    public function setMailDomainId(?int $mailDomainId): MailAlias
+    {
+        $this->mailDomainId = $mailDomainId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): MailAlias
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): MailAlias
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): MailAlias
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): MailAlias
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): MailAlias
     {
-        $mailAlias = new self();
-        $mailAlias->localPart = Arr::get($data, 'local_part');
-        $mailAlias->forwardEmailAddresses = Arr::get($data, 'forward_email_addresses', []);
-        $mailAlias->mailDomainId = Arr::get($data, 'mail_domain_id');
-        $mailAlias->id = Arr::get($data, 'id');
-        $mailAlias->clusterId = Arr::get($data, 'cluster_id');
-        $mailAlias->createdAt = Arr::get($data, 'created_at');
-        $mailAlias->updatedAt = Arr::get($data, 'updated_at');
-        return $mailAlias;
+        return $this
+            ->setLocalPart(Arr::get($data, 'local_part'))
+            ->setForwardEmailAddresses(Arr::get($data, 'forward_email_addresses', []))
+            ->setMailDomainId(Arr::get($data, 'mail_domain_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'local_part' => $this->localPart,
-            'forward_email_addresses' => $this->forwardEmailAddresses,
-            'mail_domain_id' => $this->mailDomainId,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'local_part' => $this->getLocalPart(),
+            'forward_email_addresses' => $this->getForwardEmailAddresses(),
+            'mail_domain_id' => $this->getMailDomainId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/MailDomain.php
+++ b/src/Models/MailDomain.php
@@ -5,42 +5,137 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class MailDomain implements Model
+class MailDomain extends ClusterModel implements Model
 {
-    public string $domain;
-    public array $catchAllForwardEmailAddresses = [];
-    public bool $isLocal = true;
-    public int $unixUserId;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $domain;
+    private array $catchAllForwardEmailAddresses = [];
+    private bool $isLocal = true;
+    private int $unixUserId;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getDomain(): string
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(string $domain): MailDomain
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
+
+    public function getCatchAllForwardEmailAddresses(): array
+    {
+        return $this->catchAllForwardEmailAddresses;
+    }
+
+    public function setCatchAllForwardEmailAddresses(array $catchAllForwardEmailAddresses): MailDomain
+    {
+        $this->catchAllForwardEmailAddresses = $catchAllForwardEmailAddresses;
+
+        return $this;
+    }
+
+    public function isLocal(): bool
+    {
+        return $this->isLocal;
+    }
+
+    public function setIsLocal(bool $isLocal): MailDomain
+    {
+        $this->isLocal = $isLocal;
+
+        return $this;
+    }
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): MailDomain
+    {
+        $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): MailDomain
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): MailDomain
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): MailDomain
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): MailDomain
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): MailDomain
     {
-        $mailDomain = new self();
-        $mailDomain->domain = Arr::get($data, 'domain');
-        $mailDomain->catchAllForwardEmailAddresses = Arr::get($data, 'catch_all_forward_email_addresses', []);
-        $mailDomain->isLocal = Arr::get($data, 'is_local');
-        $mailDomain->unixUserId = Arr::get($data, 'unix_user_id');
-        $mailDomain->id = Arr::get($data, 'id');
-        $mailDomain->clusterId = Arr::get($data, 'cluster_id');
-        $mailDomain->createdAt = Arr::get($data, 'created_at');
-        $mailDomain->updatedAt = Arr::get($data, 'updated_at');
-        return $mailDomain;
+        return $this
+            ->setDomain(Arr::get($data, 'domain'))
+            ->setCatchAllForwardEmailAddresses(Arr::get($data, 'catch_all_forward_email_addresses', []))
+            ->setIsLocal(Arr::get($data, 'is_local'))
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'domain' => $this->domain,
-            'catch_all_forward_email_addresses' => $this->catchAllForwardEmailAddresses,
-            'is_local' => $this->isLocal,
-            'unix_user_id' => $this->unixUserId,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'domain' => $this->getDomain(),
+            'catch_all_forward_email_addresses' => $this->getCatchAllForwardEmailAddresses(),
+            'is_local' => $this->isLocal(),
+            'unix_user_id' => $this->getUnixUserId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/Malware.php
+++ b/src/Models/Malware.php
@@ -5,39 +5,122 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Malware implements Model
+class Malware extends ClusterModel implements Model
 {
-    public string $name;
-    public string $path;
-    public int $virtualHostId;
-    public int $id;
-    public int $clusterId;
-    public string $createdAt;
-    public string $updatedAt;
+    private string $name;
+    private string $path;
+    private int $virtualHostId;
+    private int $id;
+    private int $clusterId;
+    private string $createdAt;
+    private string $updatedAt;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): Malware
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function setPath(string $path): Malware
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function getVirtualHostId(): int
+    {
+        return $this->virtualHostId;
+    }
+
+    public function setVirtualHostId(int $virtualHostId): Malware
+    {
+        $this->virtualHostId = $virtualHostId;
+
+        return $this;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): Malware
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(int $clusterId): Malware
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(string $createdAt): Malware
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(string $updatedAt): Malware
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Malware
     {
-        $malware = new self();
-        $malware->name = Arr::get($data, 'name');
-        $malware->path = Arr::get($data, 'path');
-        $malware->virtualHostId = Arr::get($data, 'virtual_host_id');
-        $malware->id = Arr::get($data, 'id');
-        $malware->clusterId = Arr::get($data, 'cluster_id');
-        $malware->createdAt = Arr::get($data, 'created_at');
-        $malware->updatedAt = Arr::get($data, 'updated_at');
-        return $malware;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setPath(Arr::get($data, 'path'))
+            ->setVirtualHostId(Arr::get($data, 'virtual_host_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'path' => $this->path,
-            'virtual_host_id' => $this->virtualHostId,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'path' => $this->getPath(),
+            'virtual_host_id' => $this->getVirtualHostId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/SshKey.php
+++ b/src/Models/SshKey.php
@@ -5,39 +5,127 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class SshKey implements Model
+class SshKey extends ClusterModel implements Model
 {
-    public string $name;
-    public string $publicKey;
-    public int $unixUserId;
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $name;
+    private string $publicKey;
+    private int $unixUserId;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): SshKey
+    {
+        $this->validate($name, [
+            'length_max' => 64,
+            'pattern' => '^[a-zA-Z0-9-_@:. ]+$',
+        ]);
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getPublicKey(): string
+    {
+        return $this->publicKey;
+    }
+
+    public function setPublicKey(string $publicKey): SshKey
+    {
+        $this->publicKey = $publicKey;
+
+        return $this;
+    }
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): SshKey
+    {
+        $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): SshKey
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): SshKey
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): SshKey
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): SshKey
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): SshKey
     {
-        $sshKey = new self();
-        $sshKey->name = Arr::get($data, 'name');
-        $sshKey->publicKey = Arr::get($data, 'public_key');
-        $sshKey->unixUserId = Arr::get($data, 'unix_user_id');
-        $sshKey->id = Arr::get($data, 'id');
-        $sshKey->clusterId = Arr::get($data, 'cluster_id');
-        $sshKey->createdAt = Arr::get($data, 'created_at');
-        $sshKey->updatedAt = Arr::get($data, 'updated_at');
-        return $sshKey;
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setPublicKey(Arr::get($data, 'public_key'))
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
-            'public_key' => $this->publicKey,
-            'unix_user_id' => $this->unixUserId,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'name' => $this->getName(),
+            'public_key' => $this->getPublicKey(),
+            'unix_user_id' => $this->getUnixUserId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -5,24 +5,47 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class Token implements Model
+class Token extends ClusterModel implements Model
 {
-    public string $accessToken;
-    public string $tokenType;
+    private string $accessToken;
+    private string $tokenType;
+
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    public function setAccessToken(string $accessToken): Token
+    {
+        $this->accessToken = $accessToken;
+
+        return $this;
+    }
+
+    public function getTokenType(): string
+    {
+        return $this->tokenType;
+    }
+
+    public function setTokenType(string $tokenType): Token
+    {
+        $this->tokenType = $tokenType;
+
+        return $this;
+    }
 
     public function fromArray(array $data): Token
     {
-        $login = new self();
-        $login->accessToken = Arr::get($data, 'access_token', '');
-        $login->tokenType = Arr::get($data, 'token_type', '');
-        return $login;
+        return $this
+            ->setAccessToken(Arr::get($data, 'access_token', ''))
+            ->setTokenType(Arr::get($data, 'token_type', ''));
     }
 
     public function toArray(): array
     {
         return [
-            'access_token' => $this->accessToken,
-            'token_type' => $this->tokenType,
+            'access_token' => $this->getAccessToken(),
+            'token_type' => $this->getTokenType(),
         ];
     }
 }

--- a/src/Models/UnixUser.php
+++ b/src/Models/UnixUser.php
@@ -5,48 +5,172 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class UnixUser implements Model
+class UnixUser extends ClusterModel implements Model
 {
-    public string $username;
-    public string $password;
-    public ?string $defaultPhpVersion = null;
-    public ?string $virtualHostsDirectory = null;
-    public ?string $mailDomainsDirectory = null;
-    public int $clusterId;
-    public ?int $id = null;
-    public ?int $unixId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $username;
+    private string $password;
+    private ?string $defaultPhpVersion = null;
+    private ?string $virtualHostsDirectory = null;
+    private ?string $mailDomainsDirectory = null;
+    private int $clusterId;
+    private ?int $id = null;
+    private ?int $unixId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(string $username): UnixUser
+    {
+        $this->validate($username, [
+            'length_max' => 32,
+            'pattern' => '^[a-z0-9-_]+$',
+        ]);
+
+        $this->username = $username;
+
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): UnixUser
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getDefaultPhpVersion(): ?string
+    {
+        return $this->defaultPhpVersion;
+    }
+
+    public function setDefaultPhpVersion(?string $defaultPhpVersion): UnixUser
+    {
+        $this->defaultPhpVersion = $defaultPhpVersion;
+
+        return $this;
+    }
+
+    public function getVirtualHostsDirectory(): ?string
+    {
+        return $this->virtualHostsDirectory;
+    }
+
+    public function setVirtualHostsDirectory(?string $virtualHostsDirectory): UnixUser
+    {
+        $this->virtualHostsDirectory = $virtualHostsDirectory;
+
+        return $this;
+    }
+
+    public function getMailDomainsDirectory(): ?string
+    {
+        return $this->mailDomainsDirectory;
+    }
+
+    public function setMailDomainsDirectory(?string $mailDomainsDirectory): UnixUser
+    {
+        $this->mailDomainsDirectory = $mailDomainsDirectory;
+
+        return $this;
+    }
+
+    public function getClusterId(): int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(int $clusterId): UnixUser
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): UnixUser
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getUnixId(): ?int
+    {
+        return $this->unixId;
+    }
+
+    public function setUnixId(?int $unixId): UnixUser
+    {
+        $this->unixId = $unixId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): UnixUser
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): UnixUser
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): UnixUser
     {
-        $unixUser = new self();
-        $unixUser->username = Arr::get($data, 'username');
-        $unixUser->password = Arr::get($data, 'password');
-        $unixUser->defaultPhpVersion = Arr::get($data, 'default_php_version');
-        $unixUser->virtualHostsDirectory = Arr::get($data, 'virtual_hosts_directory');
-        $unixUser->mailDomainsDirectory = Arr::get($data, 'mail_domains_directory');
-        $unixUser->unixId = Arr::get($data, 'unix_id');
-        $unixUser->id = Arr::get($data, 'id');
-        $unixUser->clusterId = Arr::get($data, 'cluster_id');
-        $unixUser->createdAt = Arr::get($data, 'created_at');
-        $unixUser->updatedAt = Arr::get($data, 'updated_at');
-        return $unixUser;
+        return $this
+            ->setUsername(Arr::get($data, 'username'))
+            ->setPassword(Arr::get($data, 'password'))
+            ->setDefaultPhpVersion(Arr::get($data, 'default_php_version'))
+            ->setVirtualHostsDirectory(Arr::get($data, 'virtual_hosts_directory'))
+            ->setMailDomainsDirectory(Arr::get($data, 'mail_domains_directory'))
+            ->setUnixId(Arr::get($data, 'unix_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'username' => $this->username,
-            'password' => $this->password,
-            'default_php_version' => $this->defaultPhpVersion,
-            'virtual_hosts_directory' => $this->virtualHostsDirectory,
-            'mail_domains_directory' => $this->mailDomainsDirectory,
-            'cluster_id' => $this->clusterId,
-            'id' => $this->id,
-            'unix_id' => $this->unixId,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'username' => $this->getUsername(),
+            'password' => $this->getPassword(),
+            'default_php_version' => $this->getDefaultPhpVersion(),
+            'virtual_hosts_directory' => $this->getVirtualHostsDirectory(),
+            'mail_domains_directory' => $this->getMailDomainsDirectory(),
+            'cluster_id' => $this->getClusterId(),
+            'id' => $this->getId(),
+            'unix_id' => $this->getUnixId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Models/UnixUserUsage.php
+++ b/src/Models/UnixUserUsage.php
@@ -5,30 +5,77 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class UnixUserUsage implements Model
+class UnixUserUsage extends ClusterModel implements Model
 {
-    public int $unixUserId;
-    public int $usage;
-    public array $files = [];
-    public string $timestamp;
+    private int $unixUserId;
+    private int $usage;
+    private array $files = [];
+    private string $timestamp;
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): UnixUserUsage
+    {
+        $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getUsage(): int
+    {
+        return $this->usage;
+    }
+
+    public function setUsage(int $usage): UnixUserUsage
+    {
+        $this->usage = $usage;
+
+        return $this;
+    }
+
+    public function getFiles(): array
+    {
+        return $this->files;
+    }
+
+    public function setFiles(array $files): UnixUserUsage
+    {
+        $this->files = $files;
+
+        return $this;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function setTimestamp(string $timestamp): UnixUserUsage
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
 
     public function fromArray(array $data): UnixUserUsage
     {
-        $unixUserUsage = new self();
-        $unixUserUsage->unixUserId = Arr::get($data, 'unix_user_id');
-        $unixUserUsage->usage = Arr::get($data, 'usage');
-        $unixUserUsage->files = Arr::get($data, 'files');
-        $unixUserUsage->timestamp = Arr::get($data, 'timestamp');
-        return $unixUserUsage;
+        return $this
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setUsage(Arr::get($data, 'usage'))
+            ->setFiles(Arr::get($data, 'files'))
+            ->setTimestamp(Arr::get($data, 'timestamp'));
     }
 
     public function toArray(): array
     {
         return [
-            'unix_user_id' => $this->unixUserId,
-            'usage' => $this->usage,
-            'files' => $this->files,
-            'timestamp' => $this->timestamp,
+            'unix_user_id' => $this->getUnixUserId(),
+            'usage' => $this->getUsage(),
+            'files' => $this->getFiles(),
+            'timestamp' => $this->getTimestamp(),
         ];
     }
 }

--- a/src/Models/UserInfo.php
+++ b/src/Models/UserInfo.php
@@ -5,33 +5,92 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class UserInfo implements Model
+class UserInfo extends ClusterModel implements Model
 {
-    public string $username;
-    public bool $isActive;
-    public bool $isProvisioningUser;
-    public bool $isSuperUser;
-    public array $clusters = [];
+    private string $username;
+    private bool $isActive;
+    private bool $isProvisioningUser;
+    private bool $isSuperUser;
+    private array $clusters = [];
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(string $username): UserInfo
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function setIsActive(bool $isActive): UserInfo
+    {
+        $this->isActive = $isActive;
+
+        return $this;
+    }
+
+    public function isProvisioningUser(): bool
+    {
+        return $this->isProvisioningUser;
+    }
+
+    public function setIsProvisioningUser(bool $isProvisioningUser): UserInfo
+    {
+        $this->isProvisioningUser = $isProvisioningUser;
+
+        return $this;
+    }
+
+    public function isSuperUser(): bool
+    {
+        return $this->isSuperUser;
+    }
+
+    public function setIsSuperUser(bool $isSuperUser): UserInfo
+    {
+        $this->isSuperUser = $isSuperUser;
+
+        return $this;
+    }
+
+    public function getClusters(): array
+    {
+        return $this->clusters;
+    }
+
+    public function setClusters(array $clusters): UserInfo
+    {
+        $this->clusters = $clusters;
+
+        return $this;
+    }
 
     public function fromArray(array $data): UserInfo
     {
-        $userInfo = new self();
-        $userInfo->username = Arr::get($data, 'username');
-        $userInfo->isActive = Arr::get($data, 'is_active');
-        $userInfo->isProvisioningUser = Arr::get($data, 'is_provisioning_user');
-        $userInfo->isSuperUser = Arr::get($data, 'is_superuser');
-        $userInfo->clusters = Arr::get($data, 'clusters', []);
-        return $userInfo;
+        return $this
+            ->setUsername(Arr::get($data, 'username'))
+            ->setIsActive(Arr::get($data, 'is_active'))
+            ->setIsProvisioningUser(Arr::get($data, 'is_provisioning_user'))
+            ->setIsSuperUser(Arr::get($data, 'is_superuser'))
+            ->setClusters(Arr::get($data, 'clusters', []));
     }
 
     public function toArray(): array
     {
         return [
-            'username' => $this->username,
-            'is_active' => $this->isActive,
-            'is_provisioning_user' => $this->isProvisioningUser,
-            'is_superuser' => $this->isSuperUser,
-            'clusters' => $this->clusters,
+            'username' => $this->getUsername(),
+            'is_active' => $this->isActive(),
+            'is_provisioning_user' => $this->isProvisioningUser(),
+            'is_superuser' => $this->isSuperUser(),
+            'clusters' => $this->getClusters(),
         ];
     }
 }

--- a/src/Models/ValidationError.php
+++ b/src/Models/ValidationError.php
@@ -5,27 +5,62 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class ValidationError implements Model
+class ValidationError extends ClusterModel implements Model
 {
-    public array $loc = [];
-    public string $msg;
-    public string $type;
+    private array $location = [];
+    private string $message;
+    private string $type;
+
+    public function getLocation(): array
+    {
+        return $this->location;
+    }
+
+    public function setLocation(array $location): ValidationError
+    {
+        $this->location = $location;
+
+        return $this;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(string $message): ValidationError
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): ValidationError
+    {
+        $this->type = $type;
+
+        return $this;
+    }
 
     public function fromArray(array $data): ValidationError
     {
-        $validationError = new self();
-        $validationError->loc = Arr::get($data, 'loc', []);
-        $validationError->msg = Arr::get($data, 'msg');
-        $validationError->type = Arr::get($data, 'type');
-        return $validationError;
+        return $this
+            ->setLocation(Arr::get($data, 'loc', []))
+            ->setMessage(Arr::get($data, 'msg'))
+            ->setType(Arr::get($data, 'type'));
     }
 
     public function toArray(): array
     {
         return [
-            'loc' => $this->loc,
-            'msg' => $this->msg,
-            'type' => $this->type,
+            'loc' => $this->getLocation(),
+            'msg' => $this->getMessage(),
+            'type' => $this->getType(),
         ];
     }
 }

--- a/src/Models/VirtualHost.php
+++ b/src/Models/VirtualHost.php
@@ -5,60 +5,232 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
-class VirtualHost implements Model
+class VirtualHost extends ClusterModel implements Model
 {
-    public string $domain;
-    public array $serverAliases = [];
-    public int $unixUserId;
-    public string $documentRoot;
-    public string $publicRoot;
-    public ?int $fpmPoolId = null;
-    public bool $forceSsl = true;
-    public ?string $customConfig = null;
-    public ?string $balancerBackendName = null;
-    public array $deployCommands = [];
-    public ?int $id = null;
-    public ?int $clusterId = null;
-    public ?string $createdAt = null;
-    public ?string $updatedAt = null;
+    private string $domain;
+    private array $serverAliases = [];
+    private int $unixUserId;
+    private string $documentRoot;
+    private string $publicRoot;
+    private ?int $fpmPoolId = null;
+    private bool $forceSsl = true;
+    private ?string $customConfig = null;
+    private ?string $balancerBackendName = null;
+    private array $deployCommands = [];
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getDomain(): string
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(string $domain): VirtualHost
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
+
+    public function getServerAliases(): array
+    {
+        return $this->serverAliases;
+    }
+
+    public function setServerAliases(array $serverAliases): VirtualHost
+    {
+        $this->serverAliases = $serverAliases;
+
+        return $this;
+    }
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): VirtualHost
+    {
+        $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getDocumentRoot(): string
+    {
+        return $this->documentRoot;
+    }
+
+    public function setDocumentRoot(string $documentRoot): VirtualHost
+    {
+        $this->documentRoot = $documentRoot;
+
+        return $this;
+    }
+
+    public function getPublicRoot(): string
+    {
+        return $this->publicRoot;
+    }
+
+    public function setPublicRoot(string $publicRoot): VirtualHost
+    {
+        $this->publicRoot = $publicRoot;
+
+        return $this;
+    }
+
+    public function getFpmPoolId(): ?int
+    {
+        return $this->fpmPoolId;
+    }
+
+    public function setFpmPoolId(?int $fpmPoolId): VirtualHost
+    {
+        $this->fpmPoolId = $fpmPoolId;
+
+        return $this;
+    }
+
+    public function isForceSsl(): bool
+    {
+        return $this->forceSsl;
+    }
+
+    public function setForceSsl(bool $forceSsl): VirtualHost
+    {
+        $this->forceSsl = $forceSsl;
+
+        return $this;
+    }
+
+    public function getCustomConfig(): ?string
+    {
+        return $this->customConfig;
+    }
+
+    public function setCustomConfig(?string $customConfig): VirtualHost
+    {
+        $this->customConfig = $customConfig;
+
+        return $this;
+    }
+
+    public function getBalancerBackendName(): ?string
+    {
+        return $this->balancerBackendName;
+    }
+
+    public function setBalancerBackendName(?string $balancerBackendName): VirtualHost
+    {
+        $this->validate($balancerBackendName, [
+            'length_max' => 64,
+            'pattern' => '^[a-z0-9-_.]+$',
+        ]);
+
+        $this->balancerBackendName = $balancerBackendName;
+
+        return $this;
+    }
+
+    public function getDeployCommands(): array
+    {
+        return $this->deployCommands;
+    }
+
+    public function setDeployCommands(array $deployCommands): VirtualHost
+    {
+        $this->deployCommands = $deployCommands;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): VirtualHost
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): VirtualHost
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): VirtualHost
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): VirtualHost
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
 
     public function fromArray(array $data): VirtualHost
     {
-        $virtualHost = new self();
-        $virtualHost->domain = Arr::get($data, 'domain');
-        $virtualHost->serverAliases = Arr::get($data, 'server_aliases', []);
-        $virtualHost->unixUserId = Arr::get($data, 'unix_user_id');
-        $virtualHost->documentRoot = Arr::get($data, 'document_root');
-        $virtualHost->publicRoot = Arr::get($data, 'public_root');
-        $virtualHost->fpmPoolId = Arr::get($data, 'fpm_pool_id');
-        $virtualHost->forceSsl = Arr::get($data, 'force_ssl');
-        $virtualHost->balancerBackendName = Arr::get($data, 'balancer_backend_name');
-        $virtualHost->customConfig = Arr::get($data, 'custom_config');
-        $virtualHost->deployCommands = Arr::get($data, 'deploy_commands', []);
-        $virtualHost->id = Arr::get($data, 'id');
-        $virtualHost->clusterId = Arr::get($data, 'cluster_id');
-        $virtualHost->createdAt = Arr::get($data, 'created_at');
-        $virtualHost->updatedAt = Arr::get($data, 'updated_at');
-        return $virtualHost;
+        return $this
+            ->setDomain(Arr::get($data, 'domain'))
+            ->setServerAliases(Arr::get($data, 'server_aliases', []))
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setDocumentRoot(Arr::get($data, 'document_root'))
+            ->setPublicRoot(Arr::get($data, 'public_root'))
+            ->setFpmPoolId(Arr::get($data, 'fpm_pool_id'))
+            ->setForceSsl(Arr::get($data, 'force_ssl'))
+            ->setBalancerBackendName(Arr::get($data, 'balancer_backend_name'))
+            ->setCustomConfig(Arr::get($data, 'custom_config'))
+            ->setDeployCommands(Arr::get($data, 'deploy_commands', []))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
     }
 
     public function toArray(): array
     {
         return [
-            'domain' => $this->domain,
-            'server_aliases' => $this->serverAliases,
-            'unix_user_id' => $this->unixUserId,
-            'document_root' => $this->documentRoot,
-            'public_root' => $this->publicRoot,
-            'fpm_pool_id' => $this->fpmPoolId,
-            'force_ssl' => $this->forceSsl,
-            'custom_config' => $this->customConfig,
-            'id' => $this->id,
-            'cluster_id' => $this->clusterId,
-            'balancer_backend_name' => $this->balancerBackendName,
-            'deploy_commands' => $this->deployCommands,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'domain' => $this->getDomain(),
+            'server_aliases' => $this->getServerAliases(),
+            'unix_user_id' => $this->getUnixUserId(),
+            'document_root' => $this->getDocumentRoot(),
+            'public_root' => $this->getPublicRoot(),
+            'fpm_pool_id' => $this->getFpmPoolId(),
+            'force_ssl' => $this->isForceSsl(),
+            'custom_config' => $this->getCustomConfig(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'balancer_backend_name' => $this->getBalancerBackendName(),
+            'deploy_commands' => $this->getDeployCommands(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
         ];
     }
 }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Support;
+
+class Str extends \Illuminate\Support\Str
+{
+    /**
+     * Determines if the pattern matches on the string.
+     *
+     * @param string $string
+     * @param string $pattern
+     * @return bool
+     */
+    public static function match(string $string, string $pattern): bool
+    {
+        return preg_match($pattern, $string) == false;
+    }
+}


### PR DESCRIPTION
# Changes

### Added

- Add several attributes to clusters.
- Add validation to several properties.

### Changed

- Update to [API version 1.28](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.28-2021-03-29)
- Change to getters and setters for the properties to allow validation of the properties. To prevent breaking 
  implementations, property access is still available but the use of the getters and setters is recommended.

# Checks

- [x] The changelog is updated (when applicable)
