### PR TITLE
Update to API version 1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
-## [1.13.0]
+## [1.14.0]
 
 ### Added
+
+- Add `is_namespaced` attribute to FPM pools.
+- Add `shell_path` enum attribute to Unix Users.
+
+### Changed
+
+- Update to [API version 1.32](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.32-2021-04-10)
+
+## [1.13.0]
+
+### Changed
 
 - Update to [API version 1.29.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.29.1-2021-04-07)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.29.1** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.32** version of the API.
 
 This package is not created or maintained by Cyberfusion.
 

--- a/src/Enums/ShellPath.php
+++ b/src/Enums/ShellPath.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class ShellPath
+{
+    public const BASH = '/bin/bash';
+    public const NO_LOGIN = '/usr/sbin/nologin';
+    public const JAIL_SHELL = '/usr/local/bin/jailshell';
+
+    public const DEFAULT = self::BASH;
+
+    public const AVAILABLE = [
+        self::BASH,
+        self::NO_LOGIN,
+        self::JAIL_SHELL,
+    ];
+}

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -14,6 +14,7 @@ class FpmPool extends ClusterModel implements Model
     private int $maxRequests = 1000;
     private int $processIdleTimeout = 600;
     private ?int $cpuLimit = null;
+    private bool $isNamespaced = false;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -108,6 +109,18 @@ class FpmPool extends ClusterModel implements Model
         return $this;
     }
 
+    public function isNamespaced(): bool
+    {
+        return $this->isNamespaced;
+    }
+
+    public function setIsNamespaced(bool $isNamespaced): FpmPool
+    {
+        $this->isNamespaced = $isNamespaced;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -166,6 +179,7 @@ class FpmPool extends ClusterModel implements Model
             ->setMaxRequests(Arr::get($data, 'max_requests'))
             ->setProcessIdleTimeout(Arr::get($data, 'process_idle_timeout'))
             ->setCpuLimit(Arr::get($data, 'cpu_limit'))
+            ->setIsNamespaced((bool)Arr::get($data, 'is_namespaced'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -182,6 +196,7 @@ class FpmPool extends ClusterModel implements Model
             'max_requests' => $this->getMaxRequests(),
             'process_idle_timeout' => $this->getProcessIdleTimeout(),
             'cpu_limit' => $this->getCpuLimit(),
+            'is_namespaced' => $this->isNamespaced(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/UnixUser.php
+++ b/src/Models/UnixUser.php
@@ -4,6 +4,7 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\ShellPath;
 
 class UnixUser extends ClusterModel implements Model
 {
@@ -12,6 +13,7 @@ class UnixUser extends ClusterModel implements Model
     private ?string $defaultPhpVersion = null;
     private ?string $virtualHostsDirectory = null;
     private ?string $mailDomainsDirectory = null;
+    private string $shellPath = ShellPath::BASH;
     private int $clusterId;
     private ?int $id = null;
     private ?int $unixId = null;
@@ -79,6 +81,22 @@ class UnixUser extends ClusterModel implements Model
     public function setMailDomainsDirectory(?string $mailDomainsDirectory): UnixUser
     {
         $this->mailDomainsDirectory = $mailDomainsDirectory;
+
+        return $this;
+    }
+
+    public function getShellPath(): string
+    {
+        return $this->shellPath;
+    }
+
+    public function setShellPath(string $shellPath): UnixUser
+    {
+        $this->validate($shellPath, [
+            'in' => ShellPath::AVAILABLE,
+        ]);
+
+        $this->shellPath = $shellPath;
 
         return $this;
     }
@@ -151,6 +169,7 @@ class UnixUser extends ClusterModel implements Model
             ->setDefaultPhpVersion(Arr::get($data, 'default_php_version'))
             ->setVirtualHostsDirectory(Arr::get($data, 'virtual_hosts_directory'))
             ->setMailDomainsDirectory(Arr::get($data, 'mail_domains_directory'))
+            ->setShellPath(Arr::get($data, 'shell_path', ShellPath::BASH))
             ->setUnixId(Arr::get($data, 'unix_id'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
@@ -166,6 +185,7 @@ class UnixUser extends ClusterModel implements Model
             'default_php_version' => $this->getDefaultPhpVersion(),
             'virtual_hosts_directory' => $this->getVirtualHostsDirectory(),
             'mail_domains_directory' => $this->getMailDomainsDirectory(),
+            'shell_path' => $this->getShellPath(),
             'cluster_id' => $this->getClusterId(),
             'id' => $this->getId(),
             'unix_id' => $this->getUnixId(),


### PR DESCRIPTION
# Changes

### Added

- Add `is_namespaced` attribute to FPM pools.
- Add `shell_path` enum attribute to Unix Users.

### Changed

- Update to [API version 1.32](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.32-2021-04-10)

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
