### PR TITLE
Add jsonSerializable support to the models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.15.0]
+
+### Added
+
+- Add jsonSerializable support to the models. This allows you to `json_encode` the models.
+
 ## [1.14.1]
 
 ### Fixed

--- a/src/Models/ClusterModel.php
+++ b/src/Models/ClusterModel.php
@@ -2,11 +2,13 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
+use JsonSerializable;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ModelException;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ValidationException;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Str;
 
-abstract class ClusterModel
+abstract class ClusterModel implements JsonSerializable, Model
 {
     /**
      * Provide fallback to allow the user of properties but still using the getters and setters.
@@ -92,5 +94,15 @@ abstract class ClusterModel
         if (count($failedValidations) !== 0) {
             throw ValidationException::validationFailed($failedValidations);
         }
+    }
+
+    /**
+     * Serializes the model to a value that can be serialized with json_encode.
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 }


### PR DESCRIPTION
# Changes

### Added

- Add jsonSerializable support to the models. This allows you to `json_encode` the models.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
