### PR TITLE
Update to API version 1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.16.0]
+
+### Added
+
+- Add `command_toolkit_enabled` attribute to Clusters.
+
+### Changed
+
+- Update to [API version 1.34](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.34-2021-04-23)
+
+### Removed
+
+- The `nologin` shell path is no longer available.
+
 ## [1.15.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.32** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.34** version of the API.
 
 This package is not created or maintained by Cyberfusion.
 

--- a/src/Enums/ShellPath.php
+++ b/src/Enums/ShellPath.php
@@ -5,14 +5,12 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
 class ShellPath
 {
     public const BASH = '/bin/bash';
-    public const NO_LOGIN = '/usr/sbin/nologin';
     public const JAIL_SHELL = '/usr/local/bin/jailshell';
 
     public const DEFAULT = self::BASH;
 
     public const AVAILABLE = [
         self::BASH,
-        self::NO_LOGIN,
         self::JAIL_SHELL,
     ];
 }

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -17,6 +17,7 @@ class Cluster extends ClusterModel implements Model
     private ?string $customerId = null;
     private ?bool $wordpressToolkitEnabled = null;
     private ?bool $databaseToolkitEnabled = null;
+    private ?bool $commandToolkitEnabled = null;
     private ?int $id = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
@@ -141,6 +142,18 @@ class Cluster extends ClusterModel implements Model
         return $this;
     }
 
+    public function isCommandToolkitEnabled(): ?bool
+    {
+        return $this->commandToolkitEnabled;
+    }
+
+    public function setCommandToolkitEnabled(?bool $commandToolkitEnabled): Cluster
+    {
+        $this->commandToolkitEnabled = $commandToolkitEnabled;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -190,6 +203,7 @@ class Cluster extends ClusterModel implements Model
             ->setCustomerId(Arr::get($data, 'customer_id'))
             ->setWordpressToolkitEnabled(Arr::get($data, 'wordpress_toolkit_enabled'))
             ->setDatabaseToolkitEnabled(Arr::get($data, 'database_toolkit_enabled'))
+            ->setCommandToolkitEnabled(Arr::get($data, 'command_toolkit_enabled'))
             ->setId(Arr::get($data, 'id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
             ->setUpdatedAt(Arr::get($data, 'updated_at'));
@@ -208,6 +222,7 @@ class Cluster extends ClusterModel implements Model
             'customer_id' => $this->getCustomerId(),
             'wordpress_toolkit_enabled' => $this->isWordpressToolkitEnabled(),
             'database_toolkit_enabled' => $this->isDatabaseToolkitEnabled(),
+            'command_toolkit_enabled' => $this->isCommandToolkitEnabled(),
             'id' => $this->getId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),


### PR DESCRIPTION
# Changes

### Added

- Add `command_toolkit_enabled` attribute to Clusters.

### Changed

- Update to [API version 1.34](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.34-2021-04-23)

### Removed

- The `nologin` shell path is no longer available.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
