### PR TITLE
Update to API version 1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.18.0]
+
+### Added
+
+- Borg repository usages and update endpoint.
+- Borg archives get endpoint.
+- Add the `BORG_SERVER` cluster group.
+- Add `private_key` property to SSH keys.
+- Add malware toolkit fields to Cluster.
+
+### Changed
+
+- Renamed `BORG` cluster group to `BORG_CLIENT` to match the spec.
+- Retention fields of a borg repository are now nullable.
+- Renamed `name` attribute of a CMS to `software_name` to match the spec.
+
 ## [1.17.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,17 @@ detailed information.
 - Add the `BORG_SERVER` cluster group.
 - Add `private_key` property to SSH keys.
 - Add malware toolkit fields to Cluster.
+- Add `unix_user_id` property to Malware.
 
 ### Changed
 
 - Renamed `BORG` cluster group to `BORG_CLIENT` to match the spec.
 - Retention fields of a borg repository are now nullable.
 - Renamed `name` attribute of a CMS to `software_name` to match the spec.
+
+### Removed
+
+- Removed the `virtual_host_id` property from malware.
 
 ## [1.17.1]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.35.1** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.45** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -19,6 +19,11 @@ class ClusterApi
         return new Endpoints\Authentication($this->client);
     }
 
+    public function borgArchives(): Endpoints\BorgArchives
+    {
+        return new Endpoints\BorgArchives($this->client);
+    }
+
     public function borgRepositories(): Endpoints\BorgRepositories
     {
         return new Endpoints\BorgRepositories($this->client);

--- a/src/Endpoints/BorgArchives.php
+++ b/src/Endpoints/BorgArchives.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\BorgArchive;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+
+class BorgArchives extends Endpoint
+{
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('borg-archives/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (! $response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'borgArchives' => array_map(
+                function (array $data) {
+                    return (new BorgArchive())->fromArray($data);
+                },
+                $response->getData()
+            ),
+        ]);
+    }
+}

--- a/src/Endpoints/SshKeys.php
+++ b/src/Endpoints/SshKeys.php
@@ -84,6 +84,7 @@ class SshKeys extends Endpoint
             ->setBody($this->filterFields($sshKey->toArray(), [
                 'name',
                 'public_key',
+                'private_key',
                 'unix_user_id',
             ]));
 
@@ -120,6 +121,7 @@ class SshKeys extends Endpoint
             ->setBody($this->filterFields($sshKey->toArray(), [
                 'name',
                 'public_key',
+                'private_key',
                 'unix_user_id',
                 'id',
                 'cluster_id',

--- a/src/Enums/ClusterGroup.php
+++ b/src/Enums/ClusterGroup.php
@@ -7,5 +7,6 @@ class ClusterGroup
     public const WEB = 'Web';
     public const EMAIL = 'Mail';
     public const DATABASE = 'Database';
-    public const BORG = 'Borg';
+    public const BORG_CLIENT = 'Borg Client';
+    public const BORG_SERVER = 'Borg Server';
 }

--- a/src/Models/BorgArchive.php
+++ b/src/Models/BorgArchive.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+
+class BorgArchive extends ClusterModel implements Model
+{
+    private string $name;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): BorgArchive
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): BorgArchive
+    {
+        return $this->setName(Arr::get($data, 'name'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->getName(),
+        ];
+    }
+}

--- a/src/Models/BorgRepository.php
+++ b/src/Models/BorgRepository.php
@@ -9,11 +9,13 @@ class BorgRepository extends ClusterModel implements Model
 {
     private string $name;
     private string $passphrase;
-    private int $keepHourly;
-    private int $keepDaily;
-    private int $keepWeekly;
-    private int $keepMonthly;
-    private int $keepYearly;
+    private ?int $keepHourly = null;
+    private ?int $keepDaily = null;
+    private ?int $keepWeekly = null;
+    private ?int $keepMonthly = null;
+    private ?int $keepYearly = null;
+    private ?string $remoteUrl = null;
+    private int $sshKeyId;
     private int $unixUserId;
     private ?int $id = null;
     private ?int $clusterId = null;
@@ -49,62 +51,86 @@ class BorgRepository extends ClusterModel implements Model
         return $this;
     }
 
-    public function getKeepHourly(): int
+    public function getKeepHourly(): ?int
     {
         return $this->keepHourly;
     }
 
-    public function setKeepHourly(int $keepHourly): BorgRepository
+    public function setKeepHourly(int $keepHourly = null): BorgRepository
     {
         $this->keepHourly = $keepHourly;
 
         return $this;
     }
 
-    public function getKeepDaily(): int
+    public function getKeepDaily(): ?int
     {
         return $this->keepDaily;
     }
 
-    public function setKeepDaily(int $keepDaily): BorgRepository
+    public function setKeepDaily(int $keepDaily = null): BorgRepository
     {
         $this->keepDaily = $keepDaily;
 
         return $this;
     }
 
-    public function getKeepWeekly(): int
+    public function getKeepWeekly(): ?int
     {
         return $this->keepWeekly;
     }
 
-    public function setKeepWeekly(int $keepWeekly): BorgRepository
+    public function setKeepWeekly(int $keepWeekly = null): BorgRepository
     {
         $this->keepWeekly = $keepWeekly;
 
         return $this;
     }
 
-    public function getKeepMonthly(): int
+    public function getKeepMonthly(): ?int
     {
         return $this->keepMonthly;
     }
 
-    public function setKeepMonthly(int $keepMonthly): BorgRepository
+    public function setKeepMonthly(int $keepMonthly = null): BorgRepository
     {
         $this->keepMonthly = $keepMonthly;
 
         return $this;
     }
 
-    public function getKeepYearly(): int
+    public function getKeepYearly(): ?int
     {
         return $this->keepYearly;
     }
 
-    public function setKeepYearly(int $keepYearly): BorgRepository
+    public function setKeepYearly(int $keepYearly = null): BorgRepository
     {
         $this->keepYearly = $keepYearly;
+
+        return $this;
+    }
+
+    public function getRemoteUrl(): ?string
+    {
+        return $this->remoteUrl;
+    }
+
+    public function setRemoteUrl(?string $remoteUrl): BorgRepository
+    {
+        $this->remoteUrl = $remoteUrl;
+
+        return $this;
+    }
+
+    public function getSshKeyId(): int
+    {
+        return $this->sshKeyId;
+    }
+
+    public function setSshKeyId(int $sshKeyId): BorgRepository
+    {
+        $this->sshKeyId = $sshKeyId;
 
         return $this;
     }
@@ -178,6 +204,8 @@ class BorgRepository extends ClusterModel implements Model
             ->setKeepDaily(Arr::get($data, 'keep_daily'))
             ->setKeepWeekly(Arr::get($data, 'keep_weekly'))
             ->setKeepMonthly(Arr::get($data, 'keep_monthly'))
+            ->setRemoteUrl(Arr::get($data, 'remote_url'))
+            ->setSshKeyId(Arr::get($data, 'ssh_key_id'))
             ->setUnixUserId(Arr::get($data, 'unix_user_id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setId(Arr::get($data, 'id'))
@@ -195,6 +223,8 @@ class BorgRepository extends ClusterModel implements Model
             'keep_weekly' => $this->getKeepWeekly(),
             'keep_monthly' => $this->getKeepMonthly(),
             'keep_yearly' => $this->getKeepYearly(),
+            'remote_url' => $this->getRemoteUrl(),
+            'ssh_key_id' => $this->getSshKeyId(),
             'unix_user_id' => $this->getUnixUserId(),
             'cluster_id' => $this->getClusterId(),
             'id' => $this->getId(),

--- a/src/Models/BorgRepositoryUsage.php
+++ b/src/Models/BorgRepositoryUsage.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+
+class BorgRepositoryUsage extends ClusterModel implements Model
+{
+    private int $borgRepositoryId;
+    private int $usage;
+    private string $timestamp;
+
+    public function getBorgRepositoryId(): int
+    {
+        return $this->borgRepositoryId;
+    }
+
+    public function setBorgRepositoryId(int $borgRepositoryId): BorgRepositoryUsage
+    {
+        $this->borgRepositoryId = $borgRepositoryId;
+
+        return $this;
+    }
+
+    public function getUsage(): int
+    {
+        return $this->usage;
+    }
+
+    public function setUsage(int $usage): BorgRepositoryUsage
+    {
+        $this->usage = $usage;
+
+        return $this;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function setTimestamp(string $timestamp): BorgRepositoryUsage
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): BorgRepositoryUsage
+    {
+        return $this
+            ->setBorgRepositoryId(Arr::get($data, 'unix_user_id'))
+            ->setUsage(Arr::get($data, 'usage'))
+            ->setTimestamp(Arr::get($data, 'timestamp'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'borg_repository_id' => $this->getBorgRepositoryId(),
+            'usages' => $this->getUsage(),
+            'timestamp' => $this->getTimestamp(),
+        ];
+    }
+}

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -18,6 +18,8 @@ class Cluster extends ClusterModel implements Model
     private ?bool $wordpressToolkitEnabled = null;
     private ?bool $databaseToolkitEnabled = null;
     private ?bool $commandToolkitEnabled = null;
+    private ?bool $malwareToolkitEnabled = null;
+    private ?bool $malwareToolkitScansEnabled = null;
     private ?int $id = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
@@ -154,6 +156,30 @@ class Cluster extends ClusterModel implements Model
         return $this;
     }
 
+    public function istMalwareToolkitEnabled(): ?bool
+    {
+        return $this->malwareToolkitEnabled;
+    }
+
+    public function setMalwareToolkitEnabled(?bool $malwareToolkitEnabled): Cluster
+    {
+        $this->malwareToolkitEnabled = $malwareToolkitEnabled;
+
+        return $this;
+    }
+
+    public function isMalwareToolkitScansEnabled(): ?bool
+    {
+        return $this->malwareToolkitScansEnabled;
+    }
+
+    public function setMalwareToolkitScansEnabled(?bool $malwareToolkitScansEnabled): Cluster
+    {
+        $this->malwareToolkitScansEnabled = $malwareToolkitScansEnabled;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -204,6 +230,8 @@ class Cluster extends ClusterModel implements Model
             ->setWordpressToolkitEnabled(Arr::get($data, 'wordpress_toolkit_enabled'))
             ->setDatabaseToolkitEnabled(Arr::get($data, 'database_toolkit_enabled'))
             ->setCommandToolkitEnabled(Arr::get($data, 'command_toolkit_enabled'))
+            ->setMalwareToolkitEnabled(Arr::get($data, 'malware_toolkit_enabled'))
+            ->setMalwareToolkitScansEnabled(Arr::get($data, 'malware_toolkit_scans_enabled'))
             ->setId(Arr::get($data, 'id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
             ->setUpdatedAt(Arr::get($data, 'updated_at'));
@@ -223,6 +251,8 @@ class Cluster extends ClusterModel implements Model
             'wordpress_toolkit_enabled' => $this->isWordpressToolkitEnabled(),
             'database_toolkit_enabled' => $this->isDatabaseToolkitEnabled(),
             'command_toolkit_enabled' => $this->isCommandToolkitEnabled(),
+            'malware_toolkit_enabled' => $this->istMalwareToolkitEnabled(),
+            'malware_toolkit_scans_enabled' => $this->isMalwareToolkitScansEnabled(),
             'id' => $this->getId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),

--- a/src/Models/Cms.php
+++ b/src/Models/Cms.php
@@ -7,7 +7,7 @@ use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class Cms extends ClusterModel implements Model
 {
-    private string $name;
+    private string $softwareName;
     private int $virtualHostId;
     private ?string $oneTimeLoginUrl = null;
     private int $id;
@@ -15,14 +15,14 @@ class Cms extends ClusterModel implements Model
     private string $createdAt;
     private string $updatedAt;
 
-    public function getName(): string
+    public function getSoftwareName(): string
     {
-        return $this->name;
+        return $this->softwareName;
     }
 
-    public function setName(string $name): Cms
+    public function setSoftwareName(string $softwareName): Cms
     {
-        $this->name = $name;
+        $this->softwareName = $softwareName;
 
         return $this;
     }
@@ -102,7 +102,7 @@ class Cms extends ClusterModel implements Model
     public function fromArray(array $data): Cms
     {
         return $this
-            ->setName(Arr::get($data, 'name'))
+            ->setSoftwareName(Arr::get($data, 'software_name'))
             ->setVirtualHostId(Arr::get($data, 'virtual_host_id'))
             ->setOneTimeLoginUrl(Arr::get($data, 'one_time_login_url'))
             ->setId(Arr::get($data, 'id'))
@@ -114,7 +114,7 @@ class Cms extends ClusterModel implements Model
     public function toArray(): array
     {
         return [
-            'name' => $this->getName(),
+            'software_name' => $this->getSoftwareName(),
             'virtual_host_id' => $this->getVirtualHostId(),
             'one_time_login_url' => $this->getOneTimeLoginUrl(),
             'id' => $this->getId(),

--- a/src/Models/Malware.php
+++ b/src/Models/Malware.php
@@ -9,7 +9,8 @@ class Malware extends ClusterModel implements Model
 {
     private string $name;
     private string $path;
-    private int $virtualHostId;
+    private string $lastSeenAt;
+    private int $unixUserId;
     private int $id;
     private int $clusterId;
     private string $createdAt;
@@ -39,14 +40,26 @@ class Malware extends ClusterModel implements Model
         return $this;
     }
 
-    public function getVirtualHostId(): int
+    public function getLastSeenAt(): string
     {
-        return $this->virtualHostId;
+        return $this->lastSeenAt;
     }
 
-    public function setVirtualHostId(int $virtualHostId): Malware
+    public function setLastSeenAt(string $lastSeenAt): Malware
     {
-        $this->virtualHostId = $virtualHostId;
+        $this->lastSeenAt = $lastSeenAt;
+
+        return $this;
+    }
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): Malware
+    {
+        $this->unixUserId = $unixUserId;
 
         return $this;
     }
@@ -104,7 +117,8 @@ class Malware extends ClusterModel implements Model
         return $this
             ->setName(Arr::get($data, 'name'))
             ->setPath(Arr::get($data, 'path'))
-            ->setVirtualHostId(Arr::get($data, 'virtual_host_id'))
+            ->setLastSeenAt(Arr::get($data, 'last_seen_at'))
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -116,7 +130,8 @@ class Malware extends ClusterModel implements Model
         return [
             'name' => $this->getName(),
             'path' => $this->getPath(),
-            'virtual_host_id' => $this->getVirtualHostId(),
+            'last_seen_at' => $this->getLastSeenAt(),
+            'unix_user_id' => $this->getUnixUserId(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/SshKey.php
+++ b/src/Models/SshKey.php
@@ -9,6 +9,7 @@ class SshKey extends ClusterModel implements Model
 {
     private string $name;
     private string $publicKey;
+    private ?string $privateKey = null;
     private int $unixUserId;
     private ?int $id = null;
     private ?int $clusterId = null;
@@ -40,6 +41,18 @@ class SshKey extends ClusterModel implements Model
     public function setPublicKey(string $publicKey): SshKey
     {
         $this->publicKey = $publicKey;
+
+        return $this;
+    }
+
+    public function getPrivateKey(): ?string
+    {
+        return $this->privateKey;
+    }
+
+    public function setPrivateKey(?string $privateKey): SshKey
+    {
+        $this->privateKey = $privateKey;
 
         return $this;
     }
@@ -109,6 +122,7 @@ class SshKey extends ClusterModel implements Model
         return $this
             ->setName(Arr::get($data, 'name'))
             ->setPublicKey(Arr::get($data, 'public_key'))
+            ->setPrivateKey(Arr::get($data, 'private_key'))
             ->setUnixUserId(Arr::get($data, 'unix_user_id'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
@@ -121,6 +135,7 @@ class SshKey extends ClusterModel implements Model
         return [
             'name' => $this->getName(),
             'public_key' => $this->getPublicKey(),
+            'private_key' => $this->getPrivateKey(),
             'unix_user_id' => $this->getUnixUserId(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),


### PR DESCRIPTION
# Changes

### Added

- Borg repository usages and update endpoint.
- Borg archives get endpoint.
- Add the `BORG_SERVER` cluster group.
- Add `private_key` property to SSH keys.
- Add malware toolkit fields to Cluster.
- Add `unix_user_id` property to Malware.

### Changed

- Renamed `BORG` cluster group to `BORG_CLIENT` to match the spec.
- Retention fields of a borg repository are now nullable.
- Renamed `name` attribute of a CMS to `software_name` to match the spec.

### Removed

- Removed the `virtual_host_id` property from malware.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
