### PR TITLE
Update to API version 1.46

### DIFF
--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -44,14 +44,19 @@ class VirtualHosts extends Endpoint
 
     /**
      * @param int $id
+     * @param bool $documentRootContainsFiles
      * @return Response
      * @throws RequestException
      */
-    public function get(int $id): Response
+    public function get(int $id, bool $documentRootContainsFiles = false): Response
     {
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)
-            ->setUrl(sprintf('virtual-hosts/%d', $id));
+            ->setUrl(sprintf(
+                'virtual-hosts/%d?%s',
+                $id,
+                http_build_query(['get_document_root_contains_files' => $documentRootContainsFiles])
+            ));
 
         $response = $this
             ->client

--- a/src/Models/VirtualHost.php
+++ b/src/Models/VirtualHost.php
@@ -25,6 +25,7 @@ class VirtualHost extends ClusterModel implements Model
     private ?int $clusterId = null;
     private ?string $createdAt = null;
     private ?string $updatedAt = null;
+    private array $documentRootContainsFiles = [];
 
     public function getDomain(): string
     {
@@ -231,6 +232,18 @@ class VirtualHost extends ClusterModel implements Model
         return $this;
     }
 
+    public function getDocumentRootContainsFiles(): array
+    {
+        return $this->documentRootContainsFiles;
+    }
+
+    public function setDocumentRootContainsFiles(array $documentRootContainsFiles = []): VirtualHost
+    {
+        $this->documentRootContainsFiles = $documentRootContainsFiles;
+
+        return $this;
+    }
+
     public function fromArray(array $data): VirtualHost
     {
         return $this
@@ -249,7 +262,8 @@ class VirtualHost extends ClusterModel implements Model
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
-            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+            ->setUpdatedAt(Arr::get($data, 'updated_at'))
+            ->setDocumentRootContainsFiles(Arr::get($data, 'document_root_contains_files', []));
     }
 
     public function toArray(): array
@@ -271,6 +285,7 @@ class VirtualHost extends ClusterModel implements Model
             'allow_override_option_directives' => $this->getAllowOverrideOptionDirectives(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),
+            'document_root_contains_files' => $this->getDocumentRootContainsFiles(),
         ];
     }
 }


### PR DESCRIPTION
# Changes

### Added

- Add `get_document_root_contains_files` parameter to the `get` method on VirtualHost.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
