### PR TITLE
Add default empty string to setName in fromArray on the Cluster model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.21.2]
+
+### Changed
+
+- Add default of empty string to setName in Cluster model's fromArray
+
 ## [1.21.1]
 
 ### Changed

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -219,7 +219,7 @@ class Cluster extends ClusterModel implements Model
     public function fromArray(array $data): Cluster
     {
         return $this
-            ->setName(Arr::get($data, 'name'))
+            ->setName(Arr::get($data, 'name', ''))
             ->setGroups(Arr::get($data, 'groups', []))
             ->setUnixUsersHomeDirectory(Arr::get($data, 'unix_users_home_directory'))
             ->setDatabasesDataDirectory(Arr::get($data, 'databases_data_directory'))


### PR DESCRIPTION
# Changes
Added a default empty string to the `setName` on a Cluster-model in the `fromArray` method, as the response of a cluster-commit does not contain a `name` property.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
