### PR TITLE
Fix issue with deployment and virtualhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.21.2]
+
+## Fixed
+
+- Fix error with deployment due to affected clusters not being initialized.
+- Fix error with the document root files being `null` when no files are present but an array is expected.
+
 ## [1.21.1]
 
 ### Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -23,7 +23,7 @@ class Client implements ClientContract
 
     private Configuration $configuration;
     private GuzzleClient $httpClient;
-    private array $affectedClusters;
+    private array $affectedClusters = [];
 
     /**
      * Client constructor.

--- a/src/Models/VirtualHost.php
+++ b/src/Models/VirtualHost.php
@@ -263,7 +263,7 @@ class VirtualHost extends ClusterModel implements Model
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
             ->setUpdatedAt(Arr::get($data, 'updated_at'))
-            ->setDocumentRootContainsFiles(Arr::get($data, 'document_root_contains_files', []));
+            ->setDocumentRootContainsFiles((array)Arr::get($data, 'document_root_contains_files', []));
     }
 
     public function toArray(): array


### PR DESCRIPTION
# Changes

## Fixed

- Fix error with deployment due to affected clusters not being initialized.
- Fix error with the document root files being `null` when no files are present but an array is expected.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
