### PR TITLE
Update to API version 1.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.22.0]
+
+### Added
+
+- Add regex validation to the name of a database user.
+- Add `locking_enabled` property to crons.
+
+### Changed
+
+- Change regex validation to allow capticals for the `table_name` of a database user grant.
+
 ## [1.21.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ detailed information.
 ### Changed
 
 - Change regex validation to allow capticals for the `table_name` of a database user grant.
+- Update to [API version 1.47](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.47-2021-06-04)
 
 ## [1.21.2]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.46** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.47** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Endpoints/Crons.php
+++ b/src/Endpoints/Crons.php
@@ -90,6 +90,7 @@ class Crons extends Endpoint
                 'schedule',
                 'unix_user_id',
                 'error_count',
+                'locking_enabled',
             ]));
 
         $response = $this
@@ -138,6 +139,7 @@ class Crons extends Endpoint
                 'schedule',
                 'unix_user_id',
                 'error_count',
+                'locking_enabled',
                 'id',
                 'cluster_id',
             ]));

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -13,6 +13,7 @@ class Cron extends ClusterModel implements Model
     private string $schedule;
     private int $unixUserId;
     private int $errorCount = 1;
+    private bool $lockingEnabled = true;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -95,6 +96,18 @@ class Cron extends ClusterModel implements Model
         return $this;
     }
 
+    public function isLockingEnabled(): bool
+    {
+        return $this->lockingEnabled;
+    }
+
+    public function setLockingEnabled(bool $lockingEnabled): Cron
+    {
+        $this->lockingEnabled = $lockingEnabled;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -152,6 +165,7 @@ class Cron extends ClusterModel implements Model
             ->setSchedule(Arr::get($data, 'schedule'))
             ->setUnixUserId(Arr::get($data, 'unix_user_id'))
             ->setErrorCount(Arr::get($data, 'error_count'))
+            ->setLockingEnabled(Arr::get($data, 'locking_enabled'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -167,6 +181,7 @@ class Cron extends ClusterModel implements Model
             'schedule' => $this->getSchedule(),
             'unix_user_id' => $this->getUnixUserId(),
             'error_count' => $this->getErrorCount(),
+            'locking_enabled' => $this->isLockingEnabled(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -28,6 +28,7 @@ class DatabaseUser extends ClusterModel implements Model
     {
         $this->validate($name, [
             'length_max' => 63,
+            'pattern' => '^[a-zA-Z0-9-_]+$',
         ]);
 
         $this->name = $name;

--- a/src/Models/DatabaseUserGrant.php
+++ b/src/Models/DatabaseUserGrant.php
@@ -51,7 +51,7 @@ class DatabaseUserGrant extends ClusterModel implements Model
     {
         $this->validate($tableName, [
             'length_max' => 64,
-            'pattern' => '^[a-z0-9-_]+$',
+            'pattern' => '^[a-zA-Z0-9-_]+$',
             'nullable' => true,
         ]);
 


### PR DESCRIPTION
# Changes

### Added

- Add regex validation to the name of a database user.
- Add `locking_enabled` property to crons.

### Changed

- Change regex validation to allow capticals for the `table_name` of a database user grant.
- Update to [API version 1.47](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.47-2021-06-04)

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
