### PR TITLE
Update to API version 1.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.23.0]
+
+### Changed
+
+- Requesting a Let's Encrypt certificate not longer requires a cluster deployment.
+- Update to [API version 1.48](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.48-2021-06-17)
+
 ## [1.22.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ detailed information.
 - Requesting a Let's Encrypt certificate not longer requires a cluster deployment.
 - Update to [API version 1.48](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.48-2021-06-17)
 
+### Fixed
+
+- Change the `Str::match` to `Str::doesMatch` to not conflict with new Laravel helper.
+
 ## [1.22.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.47** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.48** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Endpoints/Certificates.php
+++ b/src/Endpoints/Certificates.php
@@ -77,6 +77,8 @@ class Certificates extends Endpoint
             : ['certificate', 'ca_chain', 'private_key', 'cluster_id']; // Supply own certificate
         $this->validateRequired($certificate, 'create', $requiredAttributes);
 
+        $isLetEnscrypt = $certificate->isLetsEncrypt();
+
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
             ->setUrl('certificates')
@@ -98,9 +100,11 @@ class Certificates extends Endpoint
         $certificate = (new Certificate())->fromArray($response->getData());
 
         // Log which cluster is affected by this change
-        $this
-            ->client
-            ->addAffectedCluster($certificate->getClusterId());
+        if (!$isLetEnscrypt) {
+            $this
+                ->client
+                ->addAffectedCluster($certificate->getClusterId());
+        }
 
         return $response->setData([
             'certificate' => $certificate,

--- a/src/Models/Certificate.php
+++ b/src/Models/Certificate.php
@@ -153,4 +153,9 @@ class Certificate extends ClusterModel implements Model
             'updated_at' => $this->getUpdatedAt(),
         ];
     }
+
+    public function isLetsEncrypt(): bool
+    {
+        return count($this->commonNames) !== 0;
+    }
 }

--- a/src/Models/ClusterModel.php
+++ b/src/Models/ClusterModel.php
@@ -60,7 +60,7 @@ abstract class ClusterModel implements JsonSerializable, Model
             case 'length_max':
                 return is_string($value) && Str::length($value) <= $setting;
             case 'pattern':
-                return is_string($value) && Str::match($value, sprintf('/%s/', $setting));
+                return is_string($value) && Str::doesMatch($value, sprintf('/%s/', $setting));
             case 'in':
                 return in_array($value, $setting);
             case 'in_array':

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -11,7 +11,7 @@ class Str extends \Illuminate\Support\Str
      * @param string $pattern
      * @return bool
      */
-    public static function match(string $string, string $pattern): bool
+    public static function doesMatch(string $string, string $pattern): bool
     {
         return preg_match($pattern, $string) != false;
     }


### PR DESCRIPTION
# Changes

### Changed

- Requesting a Let's Encrypt certificate not longer requires a cluster deployment.
- Update to [API version 1.48](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.48-2021-06-17)

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
