### PR TITLE
update database usage api endpoint

### DIFF
--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -161,7 +161,14 @@ class Databases extends Endpoint
         }
 
         return $response->setData([
-            'databaseUsage' => (new DatabaseUsage())->fromArray($response->getData()),
+            'databaseUsage' => count($response->getData()) !== 0
+                ? array_map(
+                    function (array $data) {
+                        return (new DatabaseUsage())->fromArray($data);
+                    },
+                    $response->getData()
+                )
+                : null,
         ]);
     }
 }


### PR DESCRIPTION
# Changes

Changed the databases usages endpoint which now correctly sets response data as a array. Made it exacly the same as the Unix Users usages request.

# Checks

- [ ] The changelog is updated (when applicable)
- [ ] The support Cluster API version is updated in the readme (when applicable)
