### PR TITLE
Draft: Update to API version 1.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.29]
+
+### Added
+
+- Add disable async method to UNIX user endpoint.
+- Add `unit_name` to FPM pool.
+
 ## [1.28.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.65** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.77** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -138,6 +138,7 @@ class FpmPools extends Endpoint
                 'max_requests',
                 'process_idle_timeout',
                 'cpu_limit',
+                'unit_name',
                 'id',
                 'cluster_id',
             ]));

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -253,4 +253,32 @@ class UnixUsers extends Endpoint
             'unixUser' => $unixUser,
         ]);
     }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function disableAsync(int $id): Response
+    {
+        // Log the affected cluster by retrieving the model first
+        $result = $this->get($id);
+        if ($result->isSuccess()) {
+            $clusterId = $result
+                ->getData('unixUser')
+                ->getClusterId();
+
+            $this
+                ->client
+                ->addAffectedCluster($clusterId);
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('unix-users/%d/async-support', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
 }

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -15,6 +15,7 @@ class FpmPool extends ClusterModel implements Model
     private int $processIdleTimeout = 10;
     private ?int $cpuLimit = null;
     private bool $isNamespaced = false;
+    private string $unitName;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -121,6 +122,18 @@ class FpmPool extends ClusterModel implements Model
         return $this;
     }
 
+    public function getUnitName(): int
+    {
+        return $this->unitName;
+    }
+
+    public function setUnitName(int $unitName): FpmPool
+    {
+        $this->unitName = $unitName;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -180,6 +193,7 @@ class FpmPool extends ClusterModel implements Model
             ->setProcessIdleTimeout(Arr::get($data, 'process_idle_timeout'))
             ->setCpuLimit(Arr::get($data, 'cpu_limit'))
             ->setIsNamespaced((bool)Arr::get($data, 'is_namespaced'))
+            ->setUnitName(Arr::get($data, 'unit_name'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -197,6 +211,7 @@ class FpmPool extends ClusterModel implements Model
             'process_idle_timeout' => $this->getProcessIdleTimeout(),
             'cpu_limit' => $this->getCpuLimit(),
             'is_namespaced' => $this->isNamespaced(),
+            'unit_name' => $this->getUnitName(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),


### PR DESCRIPTION
# Comments

I processed the changes in API versions 1.69 and 1.72. The change in 1.68 has already been implemented in https://github.com/vdhicts/cyberfusion-cluster-api-client/pull/53

I'm not sure if the changes in API versions 1.66 and 1.76 require updates to this library.

I noticed that `is_namespaced` is not supplied in the FPM pool PUT payload. Please let me know if that's intentional or if I should create an issue.

# Changes

### Added

- Add disable async method to UNIX user endpoint.
- Add `unit_name` to FPM pool.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
