### PR TITLE
Properly encode timestamps in usage endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.30.0]
+
+### Fixed
+
+- Properly encode timestamps in usage endpoints.
+
 ## [1.29.1]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.29.1';
+    private const VERSION = '1.30.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/BorgRepositories.php
+++ b/src/Endpoints/BorgRepositories.php
@@ -75,7 +75,11 @@ class BorgRepositories extends Endpoint
      */
     public function usages(int $id, DateTimeInterface $from): Response
     {
-        $url = sprintf('borg-repositories/usages/%d?from_timestamp_date=%s', $id, $from->format('c'));
+        $url = sprintf(
+            'borg-repositories/usages/%d?%s',
+            $id,
+            http_build_query(['from_timestamp_date' => $from->format('c')])
+        );
 
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -144,7 +144,11 @@ class Databases extends Endpoint
      */
     public function usages(int $id, DateTimeInterface $from): Response
     {
-        $url = sprintf('databases/usages/%d?from_timestamp_date=%s', $id, $from->format('c'));
+        $url = sprintf(
+            'databases/usages/%d?%s',
+            $id,
+            http_build_query(['from_timestamp_date' => $from->format('c')])
+        );
 
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)

--- a/src/Endpoints/MailAccounts.php
+++ b/src/Endpoints/MailAccounts.php
@@ -75,7 +75,11 @@ class MailAccounts extends Endpoint
      */
     public function usages(int $id, DateTimeInterface $from): Response
     {
-        $url = sprintf('mail-accounts/usages/%d?from_timestamp_date=%s', $id, $from->format('c'));
+        $url = sprintf(
+            'mail-accounts/usages/%d?%s',
+            $id,
+            http_build_query(['from_timestamp_date' => $from->format('c')])
+        );
 
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -75,7 +75,11 @@ class UnixUsers extends Endpoint
      */
     public function usages(int $id, DateTimeInterface $from): Response
     {
-        $url = sprintf('unix-users/usages/%d?from_timestamp_date=%s', $id, $from->format('c'));
+        $url = sprintf(
+            'unix-users/usages/%d?%s',
+            $id,
+            http_build_query(['from_timestamp_date' => $from->format('c')])
+        );
 
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)


### PR DESCRIPTION
# Changes

Closes #62 

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
