### PR TITLE
Fix list filter for a model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.32.1]
+
+### Fixed
+
+- Use reflection instead of toArray to determine the available fields to prevent accessing fields which aren't 
+  initialized.
+
 ## [1.32.0]
 
 ### Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.32.0';
+    private const VERSION = '1.32.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Support/ListFilter.php
+++ b/src/Support/ListFilter.php
@@ -2,6 +2,8 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Support;
 
+use ReflectionClass;
+use ReflectionProperty;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Filter;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ListFilterException;
@@ -21,7 +23,13 @@ class ListFilter implements Filter
 
     public static function forModel(Model $model): self
     {
-        return (new self())->setAvailableFields($model->toArray());
+        $reflection = new ReflectionClass($model);
+        $properties = array_map(
+            fn(ReflectionProperty $property) => $property->name,
+            $reflection->getProperties(ReflectionProperty::IS_PRIVATE)
+        );
+
+        return (new self())->setAvailableFields($properties);
     }
 
     public function getAvailableFields(): ?array
@@ -79,7 +87,7 @@ class ListFilter implements Filter
      */
     public function addFilter(string $field, $value): ListFilter
     {
-        if ($this->hasAvailableFields() && !Arr::has($this->availableFields, $field)) {
+        if ($this->hasAvailableFields() && !in_array($field, $this->availableFields)) {
             throw ListFilterException::fieldNotAvailable($field);
         }
 
@@ -113,7 +121,7 @@ class ListFilter implements Filter
             throw ListFilterException::invalidSortMethod($method);
         }
 
-        if ($this->hasAvailableFields() && !Arr::has($this->availableFields, $field)) {
+        if ($this->hasAvailableFields() && !in_array($field, $this->availableFields)) {
             throw ListFilterException::fieldNotAvailable($field);
         }
 

--- a/tests/Support/LogFilterTest.php
+++ b/tests/Support/LogFilterTest.php
@@ -45,7 +45,7 @@ class LogFilterTest extends TestCase
             ->setShowRawMessage($showRawMessage);
 
         $this->assertSame(
-            'timestamp=2021-11-20T00%3A00%3A00%2B00%3A00&limit=100&show_raw_message=1',
+            'timestamp=' . $timestamp->format('Y-m-d') . 'T00%3A00%3A00%2B00%3A00&limit=100&show_raw_message=1',
             $logFilter->toQuery()
         );
     }


### PR DESCRIPTION
# Changes

### Fixed

- Use reflection instead of toArray to determine the available fields to prevent accessing fields which aren't 
  initialized.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
