### PR TITLE
Update to API version 1.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ detailed information.
 - Update to [API version 1.97](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.97-2021-12-02).
 - Always send the hashed password for the Database User but be able to set the hashed password with `setHashedPassword`
   or plain text password with `setPassword`. Thanks to @mbardelmeijer.
+- Setting the Database Engine of the Database User after setting the password will result in a `ModelException` as the
+  password hash is based on the engine.
 
 ## [1.32.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.33.0]
+
+## Changed
+
+- Update to [API version 1.97](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.97-2021-12-02).
+- Always send the hashed password for the Database User but be able to set the hashed password with `setHashedPassword`
+  or plain text password with `setPassword`. Thanks to @mbardelmeijer.
+
 ## [1.32.2]
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.88** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.97** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.32.2';
+    private const VERSION = '1.33.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Exceptions/ClusterApiException.php
+++ b/src/Exceptions/ClusterApiException.php
@@ -17,6 +17,7 @@ class ClusterApiException extends Exception
     protected const API_NOT_UP = 300;
 
     protected const MODEL_PROPERTY_NOT_AVAILABLE = 400;
+    protected const MODEL_ENGINE_SET_AFTER_PASSWORD = 401;
 
     protected const VALIDATION_FAILED = 500;
 

--- a/src/Exceptions/ModelException.php
+++ b/src/Exceptions/ModelException.php
@@ -14,4 +14,13 @@ class ModelException extends ClusterApiException
             $previous
         );
     }
+
+    public static function engineSetAfterPassword(Throwable $previous = null): ModelException
+    {
+        return new self(
+            'Set the engine name before setting the password as that will be hashed Engine specific',
+            self::MODEL_ENGINE_SET_AFTER_PASSWORD,
+            $previous
+        );
+    }
 }


### PR DESCRIPTION
# Changes

## Changed

- Update to [API version 1.97](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.97-2021-12-02).
- Always send the hashed password for the Database User but be able to set the hashed password with `setHashedPassword`
  or plain text password with `setPassword`. Thanks to @mbardelmeijer.
- Setting the Database Engine of the Database User after setting the password will result in a `ModelException` as the
  password hash is based on the engine.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
