### PR TITLE
Use digest for the inner SHA-1 hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Please note this changelog affects this package and not the 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
+
+## [1.33.1]
+
+## Fixed
+
+- The MariaDB password hash for Database Users is now generated correctly.
 
 ## [1.33.0]
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.33.0';
+    private const VERSION = '1.33.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -65,7 +65,7 @@ class DatabaseUser extends ClusterModel implements Model
                 $this->hashedPassword = sprintf('md5%s', md5($password));
                 break;
             default:
-                $this->hashedPassword = sprintf("*%s", strtoupper(sha1(sha1($password))));
+                $this->hashedPassword = sprintf("*%s", strtoupper(sha1(sha1($password, true), false)));
         }
 
         return $this;


### PR DESCRIPTION
# Changes

I tested the implementation from https://github.com/vdhicts/cyberfusion-cluster-api-client/pull/77, which requires a small fix, which is provided by this PR.

The inner SHA-1 hash should be a binary digest with a length of 20 chars. The outer SHA-1 hash should be hexadecimal number with a length of 40 chars.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
