### PR TITLE
Prepare update to API version 1.101

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,17 +3,13 @@ name: Bug report
 about: Create a report to help us improve
 title: ""
 labels: bug
-assignees: vdhicts
+assignees: dvdheiden
 
 ---
 
 ## Describe the bug
 
 A clear and concise description of what the bug is.
-
-## Affects
-
-For example: unix-users endpoint
 
 ## Reproduction
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ""
 labels: feature
-assignees: vdhicts
+assignees: dvdheiden
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.34.0]
+
+### Added
+
+- Add the Let's Encrypt certificate endpoint: `createLetsEncryptCertificate`.
+- Add the endpoint to provide your own SSL certificates: `createCertificateWithOwnMaterial`.
+
+### Changed
+
+- Update to [API version 1.101](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.101-2021-12-14).
+- Issue templates to assign the correct user instead of the organisation. Also made the bug report a bit easier to use.
+
+### Fixed
+
+- Not all headers in this changelog were of the correct depth.
+
+### Removed
+
+- Remove the `common_names` and `main_common_name` from the certificate update as it can't be changed.
+- Remove the SSH key update endpoint as it's no longer available.
+
 ## [1.33.1]
 
-## Fixed
+### Fixed
 
 - The MariaDB password hash for Database Users is now generated correctly.
 
-## [1.33.0]
+### [1.33.0]
 
 ## Changed
 
@@ -25,7 +46,7 @@ detailed information.
 
 ## [1.32.2]
 
-## Fixed
+### Fixed
 
 - Make e-mailaddress of the Cron and the unit name of the FPM pool optional.
 
@@ -406,7 +427,7 @@ detailed information.
 - Add mail aliases endpoint.
 - Add `balancer_backend_name` to virtualhosts.
 - Add `catch_all_forward_email_addresses` to mail domain.
-- Add commit call to the cluster endpoint. See the [readme](readme.md) for more information.
+- Add commit call to the cluster endpoint. See the [readme](README.md) for more information.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.97** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.101** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.33.1';
+    private const VERSION = '1.34.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/SshKeys.php
+++ b/src/Endpoints/SshKeys.php
@@ -108,52 +108,6 @@ class SshKeys extends Endpoint
     }
 
     /**
-     * @param SshKey $sshKey
-     * @return Response
-     * @throws RequestException
-     */
-    public function update(SshKey $sshKey): Response
-    {
-        $this->validateRequired($sshKey, 'update', [
-            'name',
-            'public_key',
-            'unix_user_id',
-            'id',
-            'cluster_id',
-        ]);
-
-        $request = (new Request())
-            ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('ssh-keys/%d', $sshKey->getId()))
-            ->setBody($this->filterFields($sshKey->toArray(), [
-                'name',
-                'public_key',
-                'private_key',
-                'unix_user_id',
-                'id',
-                'cluster_id',
-            ]));
-
-        $response = $this
-            ->client
-            ->request($request);
-        if (!$response->isSuccess()) {
-            return $response;
-        }
-
-        $sshKey = (new SshKey())->fromArray($response->getData());
-
-        // Log which cluster is affected by this change
-        $this
-            ->client
-            ->addAffectedCluster($sshKey->getClusterId());
-
-        return $response->setData([
-            'sshKey' => $sshKey,
-        ]);
-    }
-
-    /**
      * @param int $id
      * @return Response
      * @throws RequestException


### PR DESCRIPTION
# Changes

As API version 1.101 has some breaking changes for the SSL certificates, I already prepared the code for the new version. Will merge as soon as the changes to the API are released.

### Added

- Add the Let's Encrypt certificate endpoint: `createLetsEncryptCertificate`.
- Add the endpoint to provide your own SSL certificates: `createCertificateWithOwnMaterial`.

### Changed

- Update to [API version 1.101](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.101-2021-12-14).
- Issue templates to assign the correct user instead of the organisation. Also made the bug report a bit easier to use.

### Fixed

- Not all headers in this changelog were of the correct depth.

### Removed

- Remove the `common_names` and `main_common_name` from the certificate update as it can't be changed.
- Remove the SSH key update endpoint as it's no longer available.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
