### PR TITLE
Update to API version 1.102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.35.0]
+
+### Added
+
+- Add the `is_lets_encrypt` property to the `Certificate` model.
+
+### Changed
+
+- Update to [API version 1.102](https://test-cluster-api.cyberfusion.nl/redoc#section/Changelog/1.102-2021-12-15).
+
 ## [1.34.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.101** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.102** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.34.0';
+    private const VERSION = '1.35.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/Certificate.php
+++ b/src/Models/Certificate.php
@@ -12,6 +12,7 @@ class Certificate extends ClusterModel implements Model
     private ?string $certificate = null;
     private ?string $caChain = null;
     private ?string $privateKey = null;
+    private bool $isLetsEncrypt = false;
     private ?int $id = null;
     private ?string $statusMessage = null;
     private ?int $clusterId = null;
@@ -74,6 +75,18 @@ class Certificate extends ClusterModel implements Model
     public function setPrivateKey(?string $privateKey): Certificate
     {
         $this->privateKey = $privateKey;
+
+        return $this;
+    }
+
+    public function isLetsEncrypt(): bool
+    {
+        return $this->isLetsEncrypt;
+    }
+
+    public function setIsLetsEncrypt(bool $isLetsEncrypt): Certificate
+    {
+        $this->isLetsEncrypt = $isLetsEncrypt;
 
         return $this;
     }
@@ -146,6 +159,7 @@ class Certificate extends ClusterModel implements Model
             ->setCertificate(Arr::get($data, 'certificate'))
             ->setCaChain(Arr::get($data, 'ca_chain'))
             ->setPrivateKey(Arr::get($data, 'private_key'))
+            ->setIsLetsEncrypt(Arr::get($data, 'is_lets_encrypt', false))
             ->setId(Arr::get($data, 'id'))
             ->setStatusMessage(Arr::get($data, 'status_message'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
@@ -161,16 +175,12 @@ class Certificate extends ClusterModel implements Model
             'certificate' => $this->getCertificate(),
             'ca_chain' => $this->getCaChain(),
             'private_key' => $this->getPrivateKey(),
+            'is_lets_encrypt' => $this->isLetsEncrypt(),
             'id' => $this->getId(),
             'status_message' => $this->getStatusMessage(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),
             'updated_at' => $this->getUpdatedAt(),
         ];
-    }
-
-    public function isLetsEncrypt(): bool
-    {
-        return count($this->commonNames) !== 0;
     }
 }


### PR DESCRIPTION
# Changes

### Added

- Add the `is_lets_encrypt` property to the `Certificate` model.

### Changed

- Update to [API version 1.102](https://test-cluster-api.cyberfusion.nl/redoc#section/Changelog/1.102-2021-12-15).

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
