### PR TITLE
Update to API version 1.103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.36.0]
+
+### Changed
+
+- Update to [API version 1.103](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.103-2021-12-16).
+
+### Fixed
+
+- Use the proper snake_case fields when using the ListFilter.
+
+### Removed
+
+- - Remove the database user grant delete endpoint as it's no longer available.
+
 ## [1.35.0]
 
 ### Added
@@ -15,7 +29,7 @@ detailed information.
 
 ### Changed
 
-- Update to [API version 1.102](https://test-cluster-api.cyberfusion.nl/redoc#section/Changelog/1.102-2021-12-15).
+- Update to [API version 1.102](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.102-2021-12-15).
 
 ## [1.34.0]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.102** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.103** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.35.0';
+    private const VERSION = '1.36.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/DatabaseUserGrants.php
+++ b/src/Endpoints/DatabaseUserGrants.php
@@ -106,32 +106,4 @@ class DatabaseUserGrants extends Endpoint
             'databaseUserGrant' => $databaseUserGrant,
         ]);
     }
-
-    /**
-     * @param int $id
-     * @return Response
-     * @throws RequestException
-     */
-    public function delete(int $id): Response
-    {
-        // Log the affected cluster by retrieving the model first
-        $result = $this->get($id);
-        if ($result->isSuccess()) {
-            $clusterId = $result
-                ->getData('databaseUserGrant')
-                ->getClusterId();
-
-            $this
-                ->client
-                ->addAffectedCluster($clusterId);
-        }
-
-        $request = (new Request())
-            ->setMethod(Request::METHOD_DELETE)
-            ->setUrl(sprintf('database-user-grants/%d', $id));
-
-        return $this
-            ->client
-            ->request($request);
-    }
 }

--- a/src/Support/ListFilter.php
+++ b/src/Support/ListFilter.php
@@ -25,7 +25,7 @@ class ListFilter implements Filter
     {
         $reflection = new ReflectionClass($model);
         $properties = array_map(
-            fn(ReflectionProperty $property) => $property->name,
+            fn(ReflectionProperty $property) => Str::snake($property->name),
             $reflection->getProperties(ReflectionProperty::IS_PRIVATE)
         );
 


### PR DESCRIPTION
# Changes

### Changed

- Update to [API version 1.103](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.103-2021-12-16).

### Fixed

- Use the proper snake_case fields when using the ListFilter.

### Removed

- Remove the database user grant delete endpoint as it's no longer available.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
