### PR TITLE
Update to API version 1.104.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.37.0]
+
+### Added
+
+- Add URL redirects endpoint.
+- 
+### Changed
+
+- Update to [API version 1.104.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.104.1-2021-12-20).
+
 ## [1.36.0]
 
 ### Changed
@@ -19,7 +29,7 @@ detailed information.
 
 ### Removed
 
-- - Remove the database user grant delete endpoint as it's no longer available.
+- Remove the database user grant delete endpoint as it's no longer available.
 
 ## [1.35.0]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.103** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.104.1** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.36.0';
+    private const VERSION = '1.37.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -109,6 +109,11 @@ class ClusterApi
         return new Endpoints\UnixUsers($this->client);
     }
 
+    public function urlRedirects(): Endpoints\UrlRedirects
+    {
+        return new Endpoints\UrlRedirects($this->client);
+    }
+
     public function virtualHosts(): Endpoints\VirtualHosts
     {
         return new Endpoints\VirtualHosts($this->client);

--- a/src/Endpoints/UrlRedirects.php
+++ b/src/Endpoints/UrlRedirects.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\UrlRedirect;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+
+class UrlRedirects extends Endpoint
+{
+    /**
+     * @param ListFilter|null $filter
+     * @return Response
+     * @throws RequestException
+     */
+    public function list(ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('url-redirects?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'urlRedirects' => array_map(
+                function (array $data) {
+                    return (new UrlRedirect())->fromArray($data);
+                },
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('url-redirects/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'urlRedirect' => (new UrlRedirect())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param UrlRedirect $urlRedirect
+     * @return Response
+     * @throws RequestException
+     */
+    public function create(UrlRedirect $urlRedirect): Response
+    {
+        $this->validateRequired($urlRedirect, 'create', [
+            'domain',
+            'server_aliases',
+            'destination_url',
+            'status_code',
+            'keep_query_parameters',
+            'keep_path',
+            'force_ssl',
+            'balancer_backend_name',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('url-redirects')
+            ->setBody($this->filterFields($urlRedirect->toArray(), [
+                'domain',
+                'server_aliases',
+                'destination_url',
+                'status_code',
+                'keep_query_parameters',
+                'keep_path',
+                'force_ssl',
+                'balancer_backend_name',
+                'cluster_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $urlRedirect = (new UrlRedirect())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($urlRedirect->getClusterId());
+
+        return $response->setData([
+            'urlRedirect' => $urlRedirect,
+        ]);
+    }
+
+    /**
+     * @param UrlRedirect $urlRedirect
+     * @return Response
+     * @throws RequestException
+     */
+    public function update(UrlRedirect $urlRedirect): Response
+    {
+        $this->validateRequired($urlRedirect, 'update', [
+            'domain',
+            'server_aliases',
+            'destination_url',
+            'status_code',
+            'keep_query_parameters',
+            'keep_path',
+            'force_ssl',
+            'balancer_backend_name',
+            'id',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('url-redirects/%d', $urlRedirect->getId()))
+            ->setBody($this->filterFields($urlRedirect->toArray(), [
+                'domain',
+                'server_aliases',
+                'destination_url',
+                'status_code',
+                'keep_query_parameters',
+                'keep_path',
+                'force_ssl',
+                'balancer_backend_name',
+                'id',
+                'cluster_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $urlRedirect = (new UrlRedirect())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($urlRedirect->getClusterId());
+
+        return $response->setData([
+            'urlRedirect' => $urlRedirect,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        // Log the affected cluster by retrieving the model first
+        $result = $this->get($id);
+        if ($result->isSuccess()) {
+            $clusterId = $result
+                ->getData('urlRedirect')
+                ->getClusterId();
+
+            $this
+                ->client
+                ->addAffectedCluster($clusterId);
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('url-redirects/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Enums/ClusterGroup.php
+++ b/src/Enums/ClusterGroup.php
@@ -9,4 +9,5 @@ class ClusterGroup
     public const DATABASE = 'Database';
     public const BORG_CLIENT = 'Borg Client';
     public const BORG_SERVER = 'Borg Server';
+    public const REDIRECT = 'Redirect';
 }

--- a/src/Enums/StatusCode.php
+++ b/src/Enums/StatusCode.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class StatusCode
+{
+    public const MULTIPLE_CHOICE = 300;
+    public const MOVED_PERMANENTLY = 301;
+    public const MOVED_TEMPORARILY = 302;
+
+    public const DEFAULT = self::MOVED_PERMANENTLY;
+
+    public const AVAILABLE = [
+        self::MULTIPLE_CHOICE,
+        self::MOVED_PERMANENTLY,
+        self::MOVED_TEMPORARILY,
+    ];
+}

--- a/src/Models/ClusterModel.php
+++ b/src/Models/ClusterModel.php
@@ -61,6 +61,8 @@ abstract class ClusterModel implements JsonSerializable, Model
                 return is_integer($value) && $value >= 0;
             case 'length_max':
                 return is_string($value) && Str::length($value) <= $setting;
+            case 'length_min':
+                return is_string($value) && Str::length($value) >= $setting;
             case 'pattern':
                 return is_string($value) && Str::doesMatch($value, sprintf('/%s/', $setting));
             case 'in':

--- a/src/Models/UrlRedirect.php
+++ b/src/Models/UrlRedirect.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\StatusCode;
+
+class UrlRedirect extends ClusterModel implements Model
+{
+    private string $domain;
+    private array $serverAliases = [];
+    private string $destinationUrl;
+    private int $statusCode = StatusCode::MOVED_PERMANENTLY;
+    private bool $keepQueryParameters = true;
+    private bool $keepPath = true;
+    private bool $forceSsl = true;
+    private ?string $balancerBackendName = null;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getDomain(): string
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(string $domain): UrlRedirect
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
+
+    public function getServerAliases(): array
+    {
+        return $this->serverAliases;
+    }
+
+    public function setServerAliases(array $serverAliases): UrlRedirect
+    {
+        $this->serverAliases = $serverAliases;
+
+        return $this;
+    }
+
+    public function getDestinationUrl(): string
+    {
+        return $this->destinationUrl;
+    }
+
+    public function setDestinationUrl(string $destinationUrl): UrlRedirect
+    {
+        $this->validate($destinationUrl, [
+            'length_max' => 2083,
+            'length_min' => 1,
+        ]);
+
+        $this->destinationUrl = $destinationUrl;
+
+        return $this;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function setStatusCode(int $statusCode): UrlRedirect
+    {
+        $this->validate($statusCode, [
+            'in' => StatusCode::AVAILABLE,
+        ]);
+
+        $this->statusCode = $statusCode;
+
+        return $this;
+    }
+
+    public function isKeepQueryParameters(): bool
+    {
+        return $this->keepQueryParameters;
+    }
+
+    public function setKeepQueryParameters(bool $keepQueryParameters): UrlRedirect
+    {
+        $this->keepQueryParameters = $keepQueryParameters;
+
+        return $this;
+    }
+
+    public function isKeepPath(): bool
+    {
+        return $this->keepPath;
+    }
+
+    public function setKeepPath(bool $keepPath): UrlRedirect
+    {
+        $this->keepPath = $keepPath;
+
+        return $this;
+    }
+
+    public function isForceSsl(): bool
+    {
+        return $this->forceSsl;
+    }
+
+    public function setForceSsl(bool $forceSsl): UrlRedirect
+    {
+        $this->forceSsl = $forceSsl;
+
+        return $this;
+    }
+
+    public function getBalancerBackendName(): ?string
+    {
+        return $this->balancerBackendName;
+    }
+
+    public function setBalancerBackendName(?string $balancerBackendName): UrlRedirect
+    {
+        $this->validate($balancerBackendName, [
+            'length_max' => 64,
+            'pattern' => '^[a-z0-9-_.]+$',
+        ]);
+
+        $this->balancerBackendName = $balancerBackendName;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): UrlRedirect
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): UrlRedirect
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): UrlRedirect
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): UrlRedirect
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): UrlRedirect
+    {
+        return $this
+            ->setDomain(Arr::get($data, 'domain'))
+            ->setServerAliases(Arr::get($data, 'server_aliases', []))
+            ->setDestinationUrl(Arr::get($data, 'destination_url'))
+            ->setStatusCode(Arr::get($data, 'status_code'))
+            ->setKeepQueryParameters(Arr::get($data, 'keep_query_parameters'))
+            ->setKeepPath(Arr::get($data, 'keep_path'))
+            ->setForceSsl(Arr::get($data, 'force_ssl'))
+            ->setBalancerBackendName(Arr::get($data, 'balancer_backend_name'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'domain' => $this->getDomain(),
+            'server_aliases' => $this->getServerAliases(),
+            'destination_url' => $this->getDestinationUrl(),
+            'status_code' => $this->getStatusCode(),
+            'keep_query_parameters' => $this->isKeepQueryParameters(),
+            'keep_path' => $this->isKeepPath(),
+            'force_ssl' => $this->isForceSsl(),
+            'balancer_backend_name' => $this->getBalancerBackendName(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}


### PR DESCRIPTION
# Changes

### Added

- Add URL redirects endpoint, example:

```php
$urlRedirect = (new UrlRedirect())
    ->setDomain('domlimev.nl')
    ->setDestinationUrl('https://www.cyberfusion.nl')
    ->setBalancerBackendName('YOUR-BALANCER-BACKEND')
    ->setClusterId(YOUR_CLUSTER_ID);
```

### Changed

- Update to [API version 1.104.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.104.1-2021-12-20).

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
