### PR TITLE
Update to API version 1.105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.38.0]
+
+### Added
+
+- Add `description` to the `UrlRedirect` model.
+
+### Changed
+
+- Update to [API version 1.105.0](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.105-2021-12-28).
+
+### Removed
+
+- Remove the `update` method from the `Certificate` endpoint.
+
 ## [1.37.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.104.1** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.105** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.37.0';
+    private const VERSION = '1.38.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/Certificates.php
+++ b/src/Endpoints/Certificates.php
@@ -135,42 +135,6 @@ class Certificates extends Endpoint
     /**
      * @throws RequestException
      */
-    public function update(Certificate $certificate): Response
-    {
-        $this->validateRequired($certificate, 'update', ['id', 'cluster_id', 'main_common_name']);
-
-        $request = (new Request())
-            ->setMethod(Request::METHOD_PATCH)
-            ->setUrl(sprintf('certificates/%d', $certificate->getId()))
-            ->setBody($this->filterFields($certificate->toArray(), [
-                'certificate',
-                'ca_chain',
-                'private_key',
-                'status_message', // Can only be changed with the proper right
-            ]));
-
-        $response = $this
-            ->client
-            ->request($request);
-        if (!$response->isSuccess()) {
-            return $response;
-        }
-
-        $certificate = (new Certificate())->fromArray($response->getData());
-
-        // Log which cluster is affected by this change
-        $this
-            ->client
-            ->addAffectedCluster($certificate->getClusterId());
-
-        return $response->setData([
-            'certificate' => $certificate,
-        ]);
-    }
-
-    /**
-     * @throws RequestException
-     */
     public function delete(int $id): Response
     {
         // Log the affected cluster by retrieving the model first

--- a/src/Models/UrlRedirect.php
+++ b/src/Models/UrlRedirect.php
@@ -16,6 +16,7 @@ class UrlRedirect extends ClusterModel implements Model
     private bool $keepPath = true;
     private bool $forceSsl = true;
     private ?string $balancerBackendName = null;
+    private ?string $description = null;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -131,6 +132,18 @@ class UrlRedirect extends ClusterModel implements Model
         return $this;
     }
 
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): UrlRedirect
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -190,6 +203,7 @@ class UrlRedirect extends ClusterModel implements Model
             ->setKeepPath(Arr::get($data, 'keep_path'))
             ->setForceSsl(Arr::get($data, 'force_ssl'))
             ->setBalancerBackendName(Arr::get($data, 'balancer_backend_name'))
+            ->setDescription(Arr::get($data, 'description'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))
@@ -207,6 +221,7 @@ class UrlRedirect extends ClusterModel implements Model
             'keep_path' => $this->isKeepPath(),
             'force_ssl' => $this->isForceSsl(),
             'balancer_backend_name' => $this->getBalancerBackendName(),
+            'description' => $this->getDescription(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'created_at' => $this->getCreatedAt(),


### PR DESCRIPTION
# Changes

### Added

- Add `description` to the `UrlRedirect` model.

### Changed

- Update to [API version 1.105.0](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.105-2021-12-28).

### Removed

- Remove the `update` method from the `Certificate` endpoint.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
