### PR TITLE
Replace status code multiple choice (300) by see other (303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.38.1]
+
+### Fixed
+
+- Replace 300 by 303 in `StatusCode`
+
 ## [1.38.0]
 
 ### Added
@@ -26,7 +32,7 @@ detailed information.
 ### Added
 
 - Add URL redirects endpoint.
-- 
+
 ### Changed
 
 - Update to [API version 1.104.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.104.1-2021-12-20).

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.38.0';
+    private const VERSION = '1.38.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Enums/StatusCode.php
+++ b/src/Enums/StatusCode.php
@@ -4,15 +4,15 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
 
 class StatusCode
 {
-    public const MULTIPLE_CHOICE = 300;
     public const MOVED_PERMANENTLY = 301;
     public const MOVED_TEMPORARILY = 302;
+    public const SEE_OTHER = 303;
 
     public const DEFAULT = self::MOVED_PERMANENTLY;
 
     public const AVAILABLE = [
-        self::MULTIPLE_CHOICE,
         self::MOVED_PERMANENTLY,
         self::MOVED_TEMPORARILY,
+        self::SEE_OTHER,
     ];
 }


### PR DESCRIPTION
# Changes

This ensures the `StatusCode` enum matches the `StatusCodeEnum` from the Cluster API.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)