### PR TITLE
Fix allow_overrides_* fields for the virtualhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.38.2]
+
+### Fixed
+
+- Make sure the `allow_override_directives` and `allow_override_option_directives` are in the request body of the 
+ `VirtualHost`. 
+
 ## [1.38.1]
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.38.1';
+    private const VERSION = '1.38.2';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -96,6 +96,8 @@ class VirtualHosts extends Endpoint
                 'custom_config',
                 'balancer_backend_name',
                 'deploy_commands',
+                'allow_override_directives',
+                'allow_override_option_directives',
             ]));
 
         $response = $this
@@ -150,6 +152,8 @@ class VirtualHosts extends Endpoint
                 'custom_config',
                 'balancer_backend_name',
                 'deploy_commands',
+                'allow_override_directives',
+                'allow_override_option_directives',
                 'id',
                 'cluster_id',
             ]));


### PR DESCRIPTION
# Changes

### Fixed

- Make sure the `allow_override_directives` and `allow_override_option_directives` are in the request body of the 
 `VirtualHost`. 

Closes #86 

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
