### PR TITLE
Update to API version 1.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.39.0]
+
+### Added
+
+- Add `log_slow_requests_threshold` attribute to the `FpmPool` model.
+- Add `createPublic` and `createPrivate` methods to the `SshKeys` endpoint for creating a public or private SSH key.
+- Add several validations for several attributes.
+- Add `sort` attribute to the `LogFilter`.
+
+### Changed
+
+- Update to [API version 1.106](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.106-2022-01-21).
+- Moved the sort and limit constants to their own enums.
+
 ## [1.38.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.105** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.106** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "scripts": {
         "test": "vendor/bin/phpunit --no-coverage",
         "test-coverage": "vendor/bin/phpunit",
-        "analyse": "vendor/bin/psalm"
+        "analyse": "vendor/bin/phpstan analyse"
     },
     "config": {
         "sort-packages": true

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.38.2';
+    private const VERSION = '1.39.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -90,6 +90,7 @@ class FpmPools extends Endpoint
                 'max_requests',
                 'process_idle_timeout',
                 'cpu_limit',
+                'log_slow_requests_threshold',
             ]));
 
         $response = $this
@@ -138,6 +139,7 @@ class FpmPools extends Endpoint
                 'max_requests',
                 'process_idle_timeout',
                 'cpu_limit',
+                'log_slow_requests_threshold',
                 'id',
                 'cluster_id',
             ]));

--- a/src/Enums/Host.php
+++ b/src/Enums/Host.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class Host
+{
+    public const HOST_ALL = '%';
+    public const HOST_LOCAL = '::1';
+
+    public const AVAILABLE = [
+        self::HOST_ALL,
+        self::HOST_LOCAL,
+    ];
+}

--- a/src/Enums/Limit.php
+++ b/src/Enums/Limit.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class Limit
+{
+    public const DEFAULT_LIMIT = 100;
+    public const MAX_LIMIT = 1000;
+}

--- a/src/Enums/Sort.php
+++ b/src/Enums/Sort.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class Sort
+{
+    public const SORT_ASC = 'ASC';
+    public const SORT_DESC = 'DESC';
+
+    public const AVAILABLE = [
+        self::SORT_ASC,
+        self::SORT_DESC,
+    ];
+}

--- a/src/Enums/Sort.php
+++ b/src/Enums/Sort.php
@@ -4,11 +4,11 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
 
 class Sort
 {
-    public const SORT_ASC = 'ASC';
-    public const SORT_DESC = 'DESC';
+    public const ASC = 'ASC';
+    public const DESC = 'DESC';
 
     public const AVAILABLE = [
-        self::SORT_ASC,
-        self::SORT_DESC,
+        self::ASC,
+        self::DESC,
     ];
 }

--- a/src/Models/BorgArchive.php
+++ b/src/Models/BorgArchive.php
@@ -16,6 +16,10 @@ class BorgArchive extends ClusterModel implements Model
 
     public function setName(string $name): BorgArchive
     {
+        $this->validate($name, [
+            ''
+        ]);
+
         $this->name = $name;
 
         return $this;

--- a/src/Models/BorgRepository.php
+++ b/src/Models/BorgRepository.php
@@ -46,6 +46,11 @@ class BorgRepository extends ClusterModel implements Model
 
     public function setPassphrase(string $passphrase): BorgRepository
     {
+        $this->validate($passphrase, [
+            'length_min' => 1,
+            'length_max' => 255,
+        ]);
+
         $this->passphrase = $passphrase;
 
         return $this;

--- a/src/Models/Certificate.php
+++ b/src/Models/Certificate.php
@@ -38,7 +38,12 @@ class Certificate extends ClusterModel implements Model
 
     public function setCommonNames(array $commonNames): Certificate
     {
-        $this->commonNames = $commonNames;
+        $this->validate($commonNames, [
+            'length_min' => 1,
+            'unique',
+        ]);
+
+        $this->commonNames = array_unique($commonNames);
 
         return $this;
     }
@@ -50,6 +55,11 @@ class Certificate extends ClusterModel implements Model
 
     public function setCertificate(?string $certificate): Certificate
     {
+        $this->validate($certificate, [
+            'nullable',
+            'length_max' => 65535,
+        ]);
+
         $this->certificate = $certificate;
 
         return $this;
@@ -62,6 +72,11 @@ class Certificate extends ClusterModel implements Model
 
     public function setCaChain(?string $caChain): Certificate
     {
+        $this->validate($caChain, [
+            'nullable',
+            'length_max' => 65535,
+        ]);
+
         $this->caChain = $caChain;
 
         return $this;
@@ -74,6 +89,11 @@ class Certificate extends ClusterModel implements Model
 
     public function setPrivateKey(?string $privateKey): Certificate
     {
+        $this->validate($privateKey, [
+            'nullable',
+            'length_max' => 65535,
+        ]);
+
         $this->privateKey = $privateKey;
 
         return $this;
@@ -110,6 +130,11 @@ class Certificate extends ClusterModel implements Model
 
     public function setStatusMessage(?string $statusMessage): Certificate
     {
+        $this->validate($statusMessage, [
+            'nullable',
+            'length_max' => 65535,
+        ]);
+
         $this->statusMessage = $statusMessage;
 
         return $this;

--- a/src/Models/ClusterModel.php
+++ b/src/Models/ClusterModel.php
@@ -60,15 +60,25 @@ abstract class ClusterModel implements JsonSerializable, Model
             case 'positive_integer':
                 return is_integer($value) && $value >= 0;
             case 'length_max':
-                return is_string($value) && Str::length($value) <= $setting;
+                return
+                    (is_string($value) && Str::length($value) <= $setting) ||
+                    (is_array($value) && count($value) <= $setting);
             case 'length_min':
-                return is_string($value) && Str::length($value) >= $setting;
+                return
+                    (is_string($value) && Str::length($value) >= $setting) ||
+                    (is_array($value) && count($value) >= $setting);
             case 'pattern':
                 return is_string($value) && Str::doesMatch($value, sprintf('/%s/', $setting));
             case 'in':
                 return in_array($value, $setting);
             case 'in_array':
                 return !array_diff($value, $setting);
+            case 'unique':
+                return is_array($value) && count(array_unique($value)) === count($value);
+            case 'ip':
+                return filter_var($value, FILTER_VALIDATE_IP) !== false;
+            case 'email':
+                return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
             default:
                 return true;
         }

--- a/src/Models/CmsInstallation.php
+++ b/src/Models/CmsInstallation.php
@@ -26,6 +26,11 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setDatabaseName(string $databaseName): CmsInstallation
     {
+        $this->validate($databaseName, [
+            'length_max' => 63,
+            'pattern' => '^[a-zA-Z0-9-_]+$',
+        ]);
+
         $this->databaseName = $databaseName;
 
         return $this;
@@ -38,6 +43,11 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setDatabaseUserName(string $databaseUserName): CmsInstallation
     {
+        $this->validate($databaseUserName, [
+            'length_max' => 63,
+            'pattern' => '^[a-zA-Z0-9-_]+$',
+        ]);
+
         $this->databaseUserName = $databaseUserName;
 
         return $this;
@@ -50,6 +60,10 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setDatabaseUserPassword(string $databaseUserPassword): CmsInstallation
     {
+        $this->validate($databaseUserPassword, [
+            'length_min' => 1,
+        ]);
+
         $this->databaseUserPassword = $databaseUserPassword;
 
         return $this;
@@ -62,6 +76,10 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setDatabaseHost(string $databaseHost): CmsInstallation
     {
+        $this->validate($databaseHost, [
+            'ip',
+        ]);
+
         $this->databaseHost = $databaseHost;
 
         return $this;
@@ -74,6 +92,11 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setSiteTitle(string $siteTitle): CmsInstallation
     {
+        $this->validate($siteTitle, [
+            'length_max' => 253,
+            'pattern' => '^[a-zA-Z0-9-_ ]+$',
+        ]);
+
         $this->siteTitle = $siteTitle;
 
         return $this;
@@ -86,6 +109,10 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setSiteUrl(string $siteUrl): CmsInstallation
     {
+        $this->validate($siteUrl, [
+            'length_max' => 2083,
+        ]);
+
         $this->siteUrl = $siteUrl;
 
         return $this;
@@ -98,6 +125,11 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setLocale(string $locale): CmsInstallation
     {
+        $this->validate($locale, [
+            'length_max' => 15,
+            'pattern' => '^[a-zA-Z_]+$',
+        ]);
+
         $this->locale = $locale;
 
         return $this;
@@ -110,6 +142,11 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setVersion(string $version): CmsInstallation
     {
+        $this->validate($version, [
+            'length_max' => 6,
+            'pattern' => '^[0-9.]+$',
+        ]);
+
         $this->version = $version;
 
         return $this;
@@ -122,6 +159,11 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setAdminUsername(string $adminUsername): CmsInstallation
     {
+        $this->validate($adminUsername, [
+            'length_max' => 60,
+            'pattern' => '^[a-zA-Z0-9-_]+$',
+        ]);
+
         $this->adminUsername = $adminUsername;
 
         return $this;
@@ -134,6 +176,10 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setAdminPassword(string $adminPassword): CmsInstallation
     {
+        $this->validate($adminPassword, [
+            'length_min' => 1,
+        ]);
+
         $this->adminPassword = $adminPassword;
 
         return $this;
@@ -146,6 +192,10 @@ class CmsInstallation extends ClusterModel implements Model
 
     public function setAdminEmailAddress(string $adminEmailAddress): CmsInstallation
     {
+        $this->validate($adminEmailAddress, [
+            'email',
+        ]);
+
         $this->adminEmailAddress = $adminEmailAddress;
 
         return $this;

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -44,6 +44,11 @@ class Cron extends ClusterModel implements Model
 
     public function setCommand(string $command): Cron
     {
+        $this->validate($command, [
+            'length_min' => 1,
+            'length_max' => 65535,
+        ]);
+
         $this->command = $command;
 
         return $this;

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -5,6 +5,7 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\DatabaseEngine;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\Host;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ModelException;
 
 class DatabaseUser extends ClusterModel implements Model
@@ -46,6 +47,7 @@ class DatabaseUser extends ClusterModel implements Model
     {
         $this->validate($host, [
             'length_max' => 253,
+            'in' => Host::AVAILABLE,
         ]);
 
         $this->host = $host;
@@ -60,6 +62,11 @@ class DatabaseUser extends ClusterModel implements Model
 
     public function setPassword(string $password): DatabaseUser
     {
+        $this->validate($password, [
+            'length_min' => 1,
+            'length_max' => 255,
+        ]);
+
         switch ($this->serverSoftwareName) {
             case DatabaseEngine::SERVER_SOFTWARE_POSTGRES:
                 $this->hashedPassword = sprintf('md5%s', md5($password));

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -14,6 +14,7 @@ class FpmPool extends ClusterModel implements Model
     private int $maxRequests = 1000;
     private int $processIdleTimeout = 10;
     private ?int $cpuLimit = null;
+    private ?int $logShowRequestsThreshold = null;
     private bool $isNamespaced = false;
     private ?string $unitName = null;
     private ?int $id = null;
@@ -126,6 +127,22 @@ class FpmPool extends ClusterModel implements Model
         return $this;
     }
 
+    public function getLogShowRequestsThreshold(): ?int
+    {
+        return $this->logShowRequestsThreshold;
+    }
+
+    public function setLogShowRequestsThreshold(?int $logShowRequestsThreshold): FpmPool
+    {
+        $this->validate($logShowRequestsThreshold, [
+            'positive_integer',
+        ]);
+
+        $this->logShowRequestsThreshold = $logShowRequestsThreshold;
+
+        return $this;
+    }
+
     public function isNamespaced(): bool
     {
         return $this->isNamespaced;
@@ -208,6 +225,7 @@ class FpmPool extends ClusterModel implements Model
             ->setMaxRequests(Arr::get($data, 'max_requests'))
             ->setProcessIdleTimeout(Arr::get($data, 'process_idle_timeout'))
             ->setCpuLimit(Arr::get($data, 'cpu_limit'))
+            ->setLogShowRequestsThreshold(Arr::get($data, 'log_slow_requests_threshold'))
             ->setIsNamespaced((bool)Arr::get($data, 'is_namespaced'))
             ->setUnitName(Arr::get($data, 'unit_name'))
             ->setId(Arr::get($data, 'id'))
@@ -226,6 +244,7 @@ class FpmPool extends ClusterModel implements Model
             'max_requests' => $this->getMaxRequests(),
             'process_idle_timeout' => $this->getProcessIdleTimeout(),
             'cpu_limit' => $this->getCpuLimit(),
+            'log_slow_requests_threshold' => $this->getLogShowRequestsThreshold(),
             'is_namespaced' => $this->isNamespaced(),
             'unit_name' => $this->getUnitName(),
             'id' => $this->getId(),

--- a/src/Models/MailAccount.php
+++ b/src/Models/MailAccount.php
@@ -24,6 +24,7 @@ class MailAccount extends ClusterModel implements Model
     public function setLocalPart(string $localPart): MailAccount
     {
         $this->validate($localPart, [
+            'pattern' => '^[a-z0-9]+$',
             'length_max' => 64,
         ]);
 

--- a/src/Models/MailAlias.php
+++ b/src/Models/MailAlias.php
@@ -23,6 +23,7 @@ class MailAlias extends ClusterModel implements Model
     public function setLocalPart(string $localPart): MailAlias
     {
         $this->validate($localPart, [
+            'pattern' => '^[a-z0-9]+$',
             'length_max' => 64,
         ]);
 
@@ -38,6 +39,11 @@ class MailAlias extends ClusterModel implements Model
 
     public function setForwardEmailAddresses(array $forwardEmailAddresses): MailAlias
     {
+        $this->validate($forwardEmailAddresses, [
+            'unique',
+            'length_min' => 1,
+        ]);
+
         $this->forwardEmailAddresses = $forwardEmailAddresses;
 
         return $this;

--- a/src/Models/MailDomain.php
+++ b/src/Models/MailDomain.php
@@ -35,6 +35,10 @@ class MailDomain extends ClusterModel implements Model
 
     public function setCatchAllForwardEmailAddresses(array $catchAllForwardEmailAddresses): MailDomain
     {
+        $this->validate($catchAllForwardEmailAddresses, [
+            'unique',
+        ]);
+
         $this->catchAllForwardEmailAddresses = $catchAllForwardEmailAddresses;
 
         return $this;

--- a/src/Models/SshKey.php
+++ b/src/Models/SshKey.php
@@ -25,7 +25,7 @@ class SshKey extends ClusterModel implements Model
     {
         $this->validate($name, [
             'length_max' => 64,
-            'pattern' => '^[a-zA-Z0-9-_@:. ]+$',
+            'pattern' => '^[a-zA-Z0-9-_]+$',
         ]);
 
         $this->name = $name;
@@ -40,6 +40,10 @@ class SshKey extends ClusterModel implements Model
 
     public function setPublicKey(string $publicKey): SshKey
     {
+        $this->validate($publicKey, [
+            'length_max' => 65535,
+        ]);
+
         $this->publicKey = $publicKey;
 
         return $this;
@@ -52,6 +56,10 @@ class SshKey extends ClusterModel implements Model
 
     public function setPrivateKey(?string $privateKey): SshKey
     {
+        $this->validate($privateKey, [
+            'length_max' => 65535,
+        ]);
+
         $this->privateKey = $privateKey;
 
         return $this;

--- a/src/Models/UnixUser.php
+++ b/src/Models/UnixUser.php
@@ -62,6 +62,11 @@ class UnixUser extends ClusterModel implements Model
 
     public function setDescription(?string $description): UnixUser
     {
+        $this->validate($description, [
+            'nullable',
+            'max_length' => 255,
+        ]);
+
         $this->description = $description;
 
         return $this;
@@ -150,6 +155,12 @@ class UnixUser extends ClusterModel implements Model
 
     public function setRabbitMqUsername(?string $rabbitMqUsername): UnixUser
     {
+        $this->validate($rabbitMqUsername, [
+            'nullable',
+            'max_length' => 32,
+            'pattern' => '^[a-z0-9]+$',
+        ]);
+
         $this->rabbitMqUsername = $rabbitMqUsername;
 
         return $this;
@@ -162,6 +173,12 @@ class UnixUser extends ClusterModel implements Model
 
     public function setRabbitMqVirtualHostName(?string $rabbitMqVirtualHostName): UnixUser
     {
+        $this->validate($rabbitMqVirtualHostName, [
+            'nullable',
+            'max_length' => 32,
+            'pattern' => '^[a-z0-9]+$',
+        ]);
+
         $this->rabbitMqVirtualHostName = $rabbitMqVirtualHostName;
 
         return $this;
@@ -174,6 +191,12 @@ class UnixUser extends ClusterModel implements Model
 
     public function setRabbitMqPassword(?string $rabbitMqPassword): UnixUser
     {
+        $this->validate($rabbitMqPassword, [
+            'nullable',
+            'max_length' => 255,
+            'pattern' => '^[a-zA-Z0-9]+$',
+        ]);
+
         $this->rabbitMqPassword = $rabbitMqPassword;
 
         return $this;

--- a/src/Models/UrlRedirect.php
+++ b/src/Models/UrlRedirect.php
@@ -41,6 +41,10 @@ class UrlRedirect extends ClusterModel implements Model
 
     public function setServerAliases(array $serverAliases): UrlRedirect
     {
+        $this->validate($serverAliases, [
+            'unique',
+        ]);
+
         $this->serverAliases = $serverAliases;
 
         return $this;

--- a/src/Models/VirtualHost.php
+++ b/src/Models/VirtualHost.php
@@ -45,6 +45,10 @@ class VirtualHost extends ClusterModel implements Model
 
     public function setServerAliases(array $serverAliases): VirtualHost
     {
+        $this->validate($serverAliases, [
+            'unique',
+        ]);
+
         $this->serverAliases = $serverAliases;
 
         return $this;
@@ -117,6 +121,11 @@ class VirtualHost extends ClusterModel implements Model
 
     public function setCustomConfig(?string $customConfig): VirtualHost
     {
+        $this->validate($customConfig, [
+            'nullable',
+            'length_max' => 65535,
+        ]);
+
         $this->customConfig = $customConfig;
 
         return $this;
@@ -160,6 +169,7 @@ class VirtualHost extends ClusterModel implements Model
     {
         $this->validate($allowOverrideDirectives, [
             'in_array' => AllowOverrideDirectives::AVAILABLE,
+            'unique',
         ]);
 
         $this->allowOverrideDirectives = $allowOverrideDirectives;
@@ -176,6 +186,7 @@ class VirtualHost extends ClusterModel implements Model
     {
         $this->validate($allowOverrideOptionDirectives, [
             'in_array' => AllowOverrideOptionDirectives::AVAILABLE,
+            'unique',
         ]);
 
         $this->allowOverrideOptionDirectives = $allowOverrideOptionDirectives;

--- a/src/Support/ListFilter.php
+++ b/src/Support/ListFilter.php
@@ -6,18 +6,16 @@ use ReflectionClass;
 use ReflectionProperty;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Filter;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\Limit;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\Sort;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ListFilterException;
 use Vdhicts\HttpQueryBuilder\Builder;
 
 class ListFilter implements Filter
 {
-    private const MAX_LIMIT = 1000;
-    public const SORT_ASC = 'ASC';
-    public const SORT_DESC = 'DESC';
-
     private ?array $availableFields = null;
     private int $skip = 0;
-    private int $limit = 100;
+    private int $limit = Limit::DEFAULT_LIMIT;
     private array $filter = [];
     private array $sort = [];
 
@@ -68,8 +66,8 @@ class ListFilter implements Filter
 
     public function setLimit(int $limit): ListFilter
     {
-        if ($limit > self::MAX_LIMIT) {
-            $limit = self::MAX_LIMIT;
+        if ($limit > Limit::MAX_LIMIT) {
+            $limit = Limit::MAX_LIMIT;
         }
         $this->limit = $limit;
 
@@ -115,9 +113,9 @@ class ListFilter implements Filter
     /**
      * @throws ListFilterException
      */
-    public function addSort(string $field, string $method = self::SORT_ASC): ListFilter
+    public function addSort(string $field, string $method = Sort::SORT_ASC): ListFilter
     {
-        if (!in_array($method, [self::SORT_ASC, self::SORT_DESC])) {
+        if (!in_array($method, Sort::AVAILABLE)) {
             throw ListFilterException::invalidSortMethod($method);
         }
 

--- a/src/Support/ListFilter.php
+++ b/src/Support/ListFilter.php
@@ -113,7 +113,7 @@ class ListFilter implements Filter
     /**
      * @throws ListFilterException
      */
-    public function addSort(string $field, string $method = Sort::SORT_ASC): ListFilter
+    public function addSort(string $field, string $method = Sort::ASC): ListFilter
     {
         if (!in_array($method, Sort::AVAILABLE)) {
             throw ListFilterException::invalidSortMethod($method);

--- a/src/Support/LogFilter.php
+++ b/src/Support/LogFilter.php
@@ -5,11 +5,15 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Support;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Filter;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\Limit;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\Sort;
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ListFilterException;
 
 class LogFilter implements Filter
 {
     private DateTimeInterface $timestamp;
-    private int $limit = 100;
+    private int $limit = Limit::DEFAULT_LIMIT;
+    private string $sort = Sort::SORT_ASC;
     private bool $showRawMessage = false;
 
     public function __construct()
@@ -36,7 +40,26 @@ class LogFilter implements Filter
 
     public function setLimit(int $limit): LogFilter
     {
+        if ($limit > Limit::MAX_LIMIT) {
+            $limit = Limit::MAX_LIMIT;
+        }
         $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function getSort(): string
+    {
+        return $this->sort;
+    }
+
+    public function setSort(string $sort = Sort::SORT_ASC): LogFilter
+    {
+        if (!in_array($sort, Sort::AVAILABLE)) {
+            throw ListFilterException::invalidSortMethod($sort);
+        }
+
+        $this->sort = $sort;
 
         return $this;
     }
@@ -58,6 +81,7 @@ class LogFilter implements Filter
         return http_build_query([
             'timestamp' => $this->timestamp->format('c'),
             'limit' => $this->limit,
+            'sort' => $this->sort,
             'show_raw_message' => $this->showRawMessage,
         ]);
     }

--- a/src/Support/LogFilter.php
+++ b/src/Support/LogFilter.php
@@ -13,7 +13,7 @@ class LogFilter implements Filter
 {
     private DateTimeInterface $timestamp;
     private int $limit = Limit::DEFAULT_LIMIT;
-    private string $sort = Sort::SORT_ASC;
+    private string $sort = Sort::ASC;
     private bool $showRawMessage = false;
 
     public function __construct()
@@ -53,7 +53,7 @@ class LogFilter implements Filter
         return $this->sort;
     }
 
-    public function setSort(string $sort = Sort::SORT_ASC): LogFilter
+    public function setSort(string $sort = Sort::ASC): LogFilter
     {
         if (!in_array($sort, Sort::AVAILABLE)) {
             throw ListFilterException::invalidSortMethod($sort);

--- a/tests/Support/LogFilterTest.php
+++ b/tests/Support/LogFilterTest.php
@@ -4,6 +4,7 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Tests\Support;
 
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\Sort;
 use Vdhicts\Cyberfusion\ClusterApi\Support\LogFilter;
 
 class LogFilterTest extends TestCase
@@ -15,6 +16,7 @@ class LogFilterTest extends TestCase
         $this->assertSame(Carbon::today()->format('c'), $logFilter->getTimestamp()->format('c'));
         $this->assertSame(100, $logFilter->getLimit());
         $this->assertFalse($logFilter->isShowRawMessage());
+        $this->assertSame(Sort::ASC, $logFilter->getSort());
     }
 
     public function testLogFilter()
@@ -26,11 +28,13 @@ class LogFilterTest extends TestCase
         $logFilter = (new LogFilter())
             ->setTimestamp($timestamp)
             ->setLimit($limit)
-            ->setShowRawMessage($showRawMessage);
+            ->setShowRawMessage($showRawMessage)
+            ->setSort(Sort::DESC);
 
         $this->assertSame($timestamp->format('c'), $logFilter->getTimestamp()->format('c'));
         $this->assertSame(100, $logFilter->getLimit());
         $this->assertSame($showRawMessage, $logFilter->isShowRawMessage());
+        $this->assertSame(Sort::DESC, $logFilter->getSort());
     }
 
     public function testToQuery()
@@ -42,10 +46,11 @@ class LogFilterTest extends TestCase
         $logFilter = (new LogFilter())
             ->setTimestamp($timestamp)
             ->setLimit($limit)
-            ->setShowRawMessage($showRawMessage);
+            ->setShowRawMessage($showRawMessage)
+            ->setSort(Sort::DESC);
 
         $this->assertSame(
-            'timestamp=' . $timestamp->format('Y-m-d') . 'T00%3A00%3A00%2B00%3A00&limit=100&show_raw_message=1',
+            'timestamp=' . $timestamp->format('Y-m-d') . 'T00%3A00%3A00%2B00%3A00&limit=100&sort=DESC&show_raw_message=1',
             $logFilter->toQuery()
         );
     }


### PR DESCRIPTION
Closes #88 

# Changes

### Added

- Add `log_slow_requests_threshold` attribute to the `FpmPool` model.
- Add `createPublic` and `createPrivate` methods to the `SshKeys` endpoint for creating a public or private SSH key.
- Add several validations for several attributes.
- Add `sort` attribute to the `LogFilter`.

### Changed

- Update to [API version 1.106](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.106-2022-01-21).
- Moved the sort and limit constants to their own enums.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
