### PR TITLE
Update to API version 1.106.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.39.1]
+
+### Changed
+
+- Update to [API version 1.106.2](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.106.2-2022-01-24).
+- Update regex for mail account and mail alias local part
+
 ## [1.39.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.106** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.106.2** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.39.0';
+    private const VERSION = '1.39.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/MailAccount.php
+++ b/src/Models/MailAccount.php
@@ -24,7 +24,7 @@ class MailAccount extends ClusterModel implements Model
     public function setLocalPart(string $localPart): MailAccount
     {
         $this->validate($localPart, [
-            'pattern' => '^[a-z0-9]+$',
+            'pattern' => '^[a-z0-9-.]+$',
             'length_max' => 64,
         ]);
 

--- a/src/Models/MailAlias.php
+++ b/src/Models/MailAlias.php
@@ -23,7 +23,7 @@ class MailAlias extends ClusterModel implements Model
     public function setLocalPart(string $localPart): MailAlias
     {
         $this->validate($localPart, [
-            'pattern' => '^[a-z0-9]+$',
+            'pattern' => '^[a-z0-9-.]+$',
             'length_max' => 64,
         ]);
 


### PR DESCRIPTION
# Changes

Update mail accounts and mail aliases local part regex to allow dots and hyphens.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
