### PR TITLE
Version 1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.41.0]
+
+### Added
+
+- Add the ability to reload an FPM pool.
+
 ## [1.40.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.106.2** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.107** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.40.0';
+    private const VERSION = '1.41.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -206,4 +206,20 @@ class FpmPools extends Endpoint
             ->client
             ->request($request);
     }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function reload(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl(sprintf('fpm-pools/%d/reload', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
 }


### PR DESCRIPTION
# Changes

Add the ability to reload an FPM pool (added in Cluster API version 1.107).

This release ups the supported Cluster API version from 1.106.2 to 1.107. @dvdheiden, please double-check that no changes have to be made to this library for Cluster API versions 1.106.3, 1.106.4 and 1.106.5.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The support Cluster API version is updated in the readme (when applicable)
