### PR TITLE
Version 1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.42.0]
+
+### Added
+
+- Add `node_id` attribute to the `Cron` model.
+
 ## [1.41.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.107** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.108** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.41.0';
+    private const VERSION = '1.42.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/Crons.php
+++ b/src/Endpoints/Crons.php
@@ -88,6 +88,7 @@ class Crons extends Endpoint
                 'email_address',
                 'schedule',
                 'unix_user_id',
+                'node_id',
                 'error_count',
                 'locking_enabled',
                 'is_active',
@@ -124,6 +125,7 @@ class Crons extends Endpoint
             'command',
             'schedule',
             'unix_user_id',
+            'node_id',
             'id',
             'cluster_id',
         ]);
@@ -137,6 +139,7 @@ class Crons extends Endpoint
                 'email_address',
                 'schedule',
                 'unix_user_id',
+                'node_id',
                 'error_count',
                 'locking_enabled',
                 'is_active',

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -13,6 +13,7 @@ class Cron extends ClusterModel implements Model
     private ?string $emailAddress = null;
     private string $schedule;
     private int $unixUserId;
+    private int $nodeId;
     private int $errorCount = 1;
     private bool $lockingEnabled = true;
     private bool $isActive = true;
@@ -92,6 +93,18 @@ class Cron extends ClusterModel implements Model
     public function setUnixUserId(int $unixUserId): Cron
     {
         $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getNodeId(): int
+    {
+        return $this->nodeId;
+    }
+
+    public function setNodeId(int $nodeId): Cron
+    {
+        $this->nodeId = $nodeId;
 
         return $this;
     }
@@ -192,6 +205,7 @@ class Cron extends ClusterModel implements Model
             ->setEmailAddress(Arr::get($data, 'email_address'))
             ->setSchedule(Arr::get($data, 'schedule'))
             ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setNodeId(Arr::get($data, 'node_id'))
             ->setErrorCount(Arr::get($data, 'error_count'))
             ->setLockingEnabled(Arr::get($data, 'locking_enabled'))
             ->setIsActive(Arr::get($data, 'is_active'))
@@ -209,6 +223,7 @@ class Cron extends ClusterModel implements Model
             'email_address' => $this->getEmailAddress(),
             'schedule' => $this->getSchedule(),
             'unix_user_id' => $this->getUnixUserId(),
+            'node_id' => $this->getNodeId(),
             'error_count' => $this->getErrorCount(),
             'locking_enabled' => $this->isLockingEnabled(),
             'is_active' => $this->isActive(),


### PR DESCRIPTION
# Changes

Add `node_id` attribute to the `Cron` model.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
