### PR TITLE
Add PHP 8.1 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,20 @@ on: [push]
 jobs:
     cluster-api-tests:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php-versions: ['7.4', '8.0', '8.1']
+
+        name: PHP ${{ matrix.php-versions }}
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v1
+              uses: actions/checkout@v2
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v1
+              uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.4'
+                  php-version: ${{ matrix.php-versions }}
                   extensions: mbstring, intl
 
             - name: Install Dependencies
@@ -26,4 +31,3 @@ jobs:
             - name: Execute static analysis
               run: |
                   vendor/bin/phpstan
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package is not created or maintained by Cyberfusion.
 
 ## Requirements
 
-This package requires at least PHP 7.4 and uses Guzzle.
+This package requires PHP 7.4 or higher and uses Guzzle.
 
 ## Installation
 


### PR DESCRIPTION
# Changes

Add tests for the supported PHP versions.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
