### PR TITLE
Fix random delay max seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.43.1]
+
+### Fixed
+
+- The cron `toArray` used `setRandomDelayMaxSeconds` instead of `getRandomDelayMaxSeconds`.
+ 
 ## [1.43.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.43.0';
+    private const VERSION = '1.43.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -243,7 +243,7 @@ class Cron extends ClusterModel implements Model
             'unix_user_id' => $this->getUnixUserId(),
             'node_id' => $this->getNodeId(),
             'error_count' => $this->getErrorCount(),
-            'random_delay_max_seconds' => $this->setRandomDelayMaxSeconds(),
+            'random_delay_max_seconds' => $this->getRandomDelayMaxSeconds(),
             'locking_enabled' => $this->isLockingEnabled(),
             'is_active' => $this->isActive(),
             'id' => $this->getId(),


### PR DESCRIPTION
# Changes

### Fixed

- The cron `toArray` used `setRandomDelayMaxSeconds` instead of `getRandomDelayMaxSeconds`.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
