### PR TITLE
Add support for Laravel 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.44.0]
+
+### Added
+
+- Add support for Laravel 9.
+
 ## [1.43.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ detailed information.
 
 - Add support for Laravel 9.
 
+### Changed
+
+- Isolated Laravel helper.
+
 ## [1.43.1]
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "illuminate/support": "^8.22",
+        "illuminate/support": "^8.22 || ^9.0",
         "nesbot/carbon": "^2.43",
         "vdhicts/http-query-builder": "^1.0"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.43.1';
+    private const VERSION = '1.44.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Client as ClientContract;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;

--- a/src/Models/AccessLog.php
+++ b/src/Models/AccessLog.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class AccessLog extends ClusterModel implements Model

--- a/src/Models/BorgArchive.php
+++ b/src/Models/BorgArchive.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class BorgArchive extends ClusterModel implements Model

--- a/src/Models/BorgRepository.php
+++ b/src/Models/BorgRepository.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/BorgRepositoryUsage.php
+++ b/src/Models/BorgRepositoryUsage.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class BorgRepositoryUsage extends ClusterModel implements Model

--- a/src/Models/Certificate.php
+++ b/src/Models/Certificate.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/Cluster.php
+++ b/src/Models/Cluster.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class Cluster extends ClusterModel implements Model

--- a/src/Models/Cms.php
+++ b/src/Models/Cms.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class Cms extends ClusterModel implements Model

--- a/src/Models/CmsInstallation.php
+++ b/src/Models/CmsInstallation.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/Database.php
+++ b/src/Models/Database.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\DatabaseEngine;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;

--- a/src/Models/DatabaseUsage.php
+++ b/src/Models/DatabaseUsage.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class DatabaseUsage extends ClusterModel implements Model

--- a/src/Models/DatabaseUser.php
+++ b/src/Models/DatabaseUser.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\DatabaseEngine;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\Host;

--- a/src/Models/DatabaseUserGrant.php
+++ b/src/Models/DatabaseUserGrant.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/DetailMessage.php
+++ b/src/Models/DetailMessage.php
@@ -2,8 +2,8 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 
 class DetailMessage extends ClusterModel implements Model
 {

--- a/src/Models/ErrorLog.php
+++ b/src/Models/ErrorLog.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class ErrorLog extends ClusterModel implements Model

--- a/src/Models/FpmPool.php
+++ b/src/Models/FpmPool.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/Health.php
+++ b/src/Models/Health.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\HealthStatus;
 

--- a/src/Models/HttpValidationError.php
+++ b/src/Models/HttpValidationError.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class HttpValidationError extends ClusterModel implements Model

--- a/src/Models/MailAccount.php
+++ b/src/Models/MailAccount.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/MailAccountUsage.php
+++ b/src/Models/MailAccountUsage.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class MailAccountUsage extends ClusterModel implements Model

--- a/src/Models/MailAlias.php
+++ b/src/Models/MailAlias.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/MailDomain.php
+++ b/src/Models/MailDomain.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/Malware.php
+++ b/src/Models/Malware.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class Malware extends ClusterModel implements Model

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/SshKey.php
+++ b/src/Models/SshKey.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class Token extends ClusterModel implements Model

--- a/src/Models/UnixUser.php
+++ b/src/Models/UnixUser.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\ShellPath;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;

--- a/src/Models/UnixUserUsage.php
+++ b/src/Models/UnixUserUsage.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class UnixUserUsage extends ClusterModel implements Model

--- a/src/Models/UrlRedirect.php
+++ b/src/Models/UrlRedirect.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\StatusCode;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;

--- a/src/Models/UserInfo.php
+++ b/src/Models/UserInfo.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class UserInfo extends ClusterModel implements Model

--- a/src/Models/ValidationError.php
+++ b/src/Models/ValidationError.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 
 class ValidationError extends ClusterModel implements Model

--- a/src/Models/VirtualHost.php
+++ b/src/Models/VirtualHost.php
@@ -2,7 +2,7 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
-use Illuminate\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\AllowOverrideDirectives;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\AllowOverrideOptionDirectives;


### PR DESCRIPTION
Closes #98 

# Changes

### Added

- Add support for Laravel 9.

### Changed

- Isolate Laravel helper.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
