### PR TITLE
Update to API version 1.110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.45.0]
+
+### Added
+
+- Add `TaskCollection` endpoint.
+- Add `callbackUrl` to cms install and fpm reload requests.
+
+### Changed
+
+- Update to API version 1.110.
+- The cms install and fpm reload request now return a `TaskCollection`.
+
 ## [1.44.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.109** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.110** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.44.0';
+    private const VERSION = '1.45.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -99,9 +99,19 @@ class ClusterApi
         return new Endpoints\Malwares($this->client);
     }
 
+    public function nodes(): Endpoints\Nodes
+    {
+        return new Endpoints\Nodes($this->client);
+    }
+
     public function sshKeys(): Endpoints\SshKeys
     {
         return new Endpoints\SshKeys($this->client);
+    }
+
+    public function taskCollections(): Endpoints\TaskCollections
+    {
+        return new Endpoints\TaskCollections($this->client);
     }
 
     public function unixUsers(): Endpoints\UnixUsers
@@ -117,10 +127,5 @@ class ClusterApi
     public function virtualHosts(): Endpoints\VirtualHosts
     {
         return new Endpoints\VirtualHosts($this->client);
-    }
-
-    public function nodes(): Endpoints\Nodes
-    {
-        return new Endpoints\Nodes($this->client);
     }
 }

--- a/src/Endpoints/TaskCollections.php
+++ b/src/Endpoints/TaskCollections.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\Node;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+
+class TaskCollections extends Endpoint
+{
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('task-collections/%d/results', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'node' => (new Node())->fromArray($response->getData()),
+        ]);
+    }
+}

--- a/src/Endpoints/TaskCollections.php
+++ b/src/Endpoints/TaskCollections.php
@@ -4,6 +4,7 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\Node;
+use Vdhicts\Cyberfusion\ClusterApi\Models\TaskCollection;
 use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;
 
@@ -28,7 +29,7 @@ class TaskCollections extends Endpoint
         }
 
         return $response->setData([
-            'node' => (new Node())->fromArray($response->getData()),
+            'taskCollection' => (new TaskCollection())->fromArray($response->getData()),
         ]);
     }
 }

--- a/src/Endpoints/TaskCollections.php
+++ b/src/Endpoints/TaskCollections.php
@@ -6,7 +6,6 @@ use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\Node;
 use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;
-use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
 
 class TaskCollections extends Endpoint
 {

--- a/src/Enums/TaskCollectionType.php
+++ b/src/Enums/TaskCollectionType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class TaskCollectionType
+{
+    public const TYPE_ASYNCHRONOUS = 'asynchronous';
+
+    public const AVAILABLE = [
+        self::TYPE_ASYNCHRONOUS,
+    ];
+}

--- a/src/Models/TaskCollection.php
+++ b/src/Models/TaskCollection.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Enums\TaskCollectionType;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
+
+class TaskCollection extends ClusterModel implements Model
+{
+    private string $uuid;
+    private string $description;
+    private string $collectionType;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(string $uuid): TaskCollection
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): TaskCollection
+    {
+        Validator::value($description)
+            ->minLength(1)
+            ->maxLength(255)
+            ->validate();
+
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getCollectionType(): string
+    {
+        return $this->collectionType;
+    }
+
+    public function setCollectionType(string $collectionType): TaskCollection
+    {
+        Validator::value($collectionType)
+            ->valueIn(TaskCollectionType::AVAILABLE)
+            ->validate();
+
+        $this->collectionType = $collectionType;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): TaskCollection
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): TaskCollection
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): TaskCollection
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): TaskCollection
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): TaskCollection
+    {
+        return $this
+            ->setUuid(Arr::get($data, 'uuid'))
+            ->setDescription(Arr::get($data, 'description'))
+            ->setCollectionType(Arr::get($data, 'collection_type'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'uuid' => $this->getUuid(),
+            'description' => $this->getDescription(),
+            'collection_type' => $this->getCollectionType(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -13,8 +13,7 @@ class Arr extends \Illuminate\Support\Arr
      */
     public static function exceptValue(array $array, $value): array
     {
-        $key = array_search($value, $array);
-        if ($key === false) {
+        if (!in_array($value, $array)) {
             return $array;
         }
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -15,4 +15,22 @@ class Str extends \Illuminate\Support\Str
     {
         return preg_match($pattern, $string) != false;
     }
+
+    /**
+     * Determines the full url based on the available optional query parameters. Filters out null values of the
+     * parameters.
+     *
+     * @param string $url
+     * @param array $parameters
+     * @return string
+     */
+    public static function optionalQueryParameters(string $url, array $parameters): string
+    {
+        $parameters = array_filter($parameters);
+        if (count($parameters) === 0) {
+            return $url;
+        }
+
+        return $url . '?' . http_build_query($parameters);
+    }
 }


### PR DESCRIPTION
# Changes

### Added

- Add `TaskCollection` endpoint.
- Add `callbackUrl` to cms install and fpm reload requests.

### Changed

- Update to API version 1.110.
- The cms install and fpm reload request now return a `TaskCollection`.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
