### PR TITLE
Update to API version 1.115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.46.0]
+
+### Added
+
+- Add the optional `timeUnit` to database, mail account, borg repository and unix user usage.
+
+### Changed
+
+- Update to [API version 1.115](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.115-2022-03-04).
+- Renamed `from_timestamp_date` parameter to `timestamp`. This does not affect the usage of the package.
+
 ## [1.45.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.110** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.115** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.45.0';
+    private const VERSION = '1.46.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/BorgRepositories.php
+++ b/src/Endpoints/BorgRepositories.php
@@ -3,6 +3,7 @@
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use DateTimeInterface;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\BorgRepository;
 use Vdhicts\Cyberfusion\ClusterApi\Models\BorgRepositoryUsage;
@@ -70,15 +71,19 @@ class BorgRepositories extends Endpoint
     /**
      * @param int $id
      * @param DateTimeInterface $from
+     * @param string $timeUnit
      * @return Response
      * @throws RequestException
      */
-    public function usages(int $id, DateTimeInterface $from): Response
+    public function usages(int $id, DateTimeInterface $from, string $timeUnit = TimeUnit::HOURLY): Response
     {
         $url = sprintf(
             'borg-repositories/usages/%d?%s',
             $id,
-            http_build_query(['from_timestamp_date' => $from->format('c')])
+            http_build_query([
+                'timestamp' => $from->format('c'),
+                'time_unit' => $timeUnit,
+            ])
         );
 
         $request = (new Request())

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -3,6 +3,7 @@
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use DateTimeInterface;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\Database;
 use Vdhicts\Cyberfusion\ClusterApi\Models\DatabaseUsage;
@@ -139,15 +140,19 @@ class Databases extends Endpoint
     /**
      * @param int $id
      * @param DateTimeInterface $from
+     * @param string $timeUnit
      * @return Response
      * @throws RequestException
      */
-    public function usages(int $id, DateTimeInterface $from): Response
+    public function usages(int $id, DateTimeInterface $from, string $timeUnit = TimeUnit::HOURLY): Response
     {
         $url = sprintf(
             'databases/usages/%d?%s',
             $id,
-            http_build_query(['from_timestamp_date' => $from->format('c')])
+            http_build_query([
+                'timestamp' => $from->format('c'),
+                'time_unit' => $timeUnit,
+            ])
         );
 
         $request = (new Request())

--- a/src/Endpoints/MailAccounts.php
+++ b/src/Endpoints/MailAccounts.php
@@ -3,6 +3,7 @@
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use DateTimeInterface;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\MailAccount;
 use Vdhicts\Cyberfusion\ClusterApi\Models\MailAccountUsage;
@@ -70,15 +71,19 @@ class MailAccounts extends Endpoint
     /**
      * @param int $id
      * @param DateTimeInterface $from
+     * @param string $timeUnit
      * @return Response
      * @throws RequestException
      */
-    public function usages(int $id, DateTimeInterface $from): Response
+    public function usages(int $id, DateTimeInterface $from, string $timeUnit = TimeUnit::HOURLY): Response
     {
         $url = sprintf(
             'mail-accounts/usages/%d?%s',
             $id,
-            http_build_query(['from_timestamp_date' => $from->format('c')])
+            http_build_query([
+                'timestamp' => $from->format('c'),
+                'time_unit' => $timeUnit,
+            ])
         );
 
         $request = (new Request())

--- a/src/Endpoints/TaskCollections.php
+++ b/src/Endpoints/TaskCollections.php
@@ -3,7 +3,6 @@
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
-use Vdhicts\Cyberfusion\ClusterApi\Models\Node;
 use Vdhicts\Cyberfusion\ClusterApi\Models\TaskCollection;
 use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -3,6 +3,7 @@
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use DateTimeInterface;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\UnixUser;
 use Vdhicts\Cyberfusion\ClusterApi\Models\UnixUserUsage;
@@ -70,15 +71,19 @@ class UnixUsers extends Endpoint
     /**
      * @param int $id
      * @param DateTimeInterface $from
+     * @param string $timeUnit
      * @return Response
      * @throws RequestException
      */
-    public function usages(int $id, DateTimeInterface $from): Response
+    public function usages(int $id, DateTimeInterface $from, string $timeUnit = TimeUnit::HOURLY): Response
     {
         $url = sprintf(
             'unix-users/usages/%d?%s',
             $id,
-            http_build_query(['from_timestamp_date' => $from->format('c')])
+            http_build_query([
+                'timestamp' => $from->format('c'),
+                'time_unit' => $timeUnit,
+            ])
         );
 
         $request = (new Request())

--- a/src/Enums/TimeUnit.php
+++ b/src/Enums/TimeUnit.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class TimeUnit
+{
+    public const HOURLY = 'hourly';
+    public const DAILY = 'daily';
+    public const WEEKLY = 'weekly';
+    public const MONTHLY = 'monthly';
+
+    public const AVAILABLE = [
+        self::HOURLY,
+        self::DAILY,
+        self::WEEKLY,
+        self::MONTHLY,
+    ];
+}


### PR DESCRIPTION
# Changes

### Added

- Add the optional `timeUnit` to database, mail account, borg repository and unix user usage.

### Changed

- Update to [API version 1.115](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.115-2022-03-04).
- Renamed `from_timestamp_date` parameter to `timestamp`. This does not affect the usage of the package.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
