### PR TITLE
Version 1.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.47.0]
+
+### Added
+
+- Add the optional `recordUsageFiles` attribute to UNIX users.
+
+### Changed
+
+- Update to [API version 1.116](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.116-2022-03-06).
+
+### Fixed
+
+- Add missing attribute to create and update payload for FPM pools: `is_namespaced`
+- Add missing attributes to create and update payloads for UNIX users: `shell_path`, `borg_repositories_directory`, `description`
+- Add missing attributes to create and update payloads for URL redirects: `description`
+
 ## [1.46.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.115** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.116** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.46.0';
+    private const VERSION = '1.47.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/FpmPools.php
+++ b/src/Endpoints/FpmPools.php
@@ -93,6 +93,7 @@ class FpmPools extends Endpoint
                 'process_idle_timeout',
                 'cpu_limit',
                 'log_slow_requests_threshold',
+                'is_namespaced',
             ]));
 
         $response = $this
@@ -142,6 +143,7 @@ class FpmPools extends Endpoint
                 'process_idle_timeout',
                 'cpu_limit',
                 'log_slow_requests_threshold',
+                'is_namespaced',
                 'id',
                 'cluster_id',
             ]));

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -174,6 +174,7 @@ class UnixUsers extends Endpoint
             ->setBody($this->filterFields($unixUser->toArray(), [
                 'username',
                 'password',
+                'record_usage_files',
                 'default_php_version',
                 'virtual_hosts_directory',
                 'mail_domains_directory',

--- a/src/Endpoints/UnixUsers.php
+++ b/src/Endpoints/UnixUsers.php
@@ -128,9 +128,12 @@ class UnixUsers extends Endpoint
             ->setBody($this->filterFields($unixUser->toArray(), [
                 'username',
                 'password',
+                'shell_path',
                 'default_php_version',
                 'virtual_hosts_directory',
                 'mail_domains_directory',
+                'borg_repositories_directory',
+                'description',
                 'cluster_id',
             ]));
 
@@ -174,10 +177,13 @@ class UnixUsers extends Endpoint
             ->setBody($this->filterFields($unixUser->toArray(), [
                 'username',
                 'password',
-                'record_usage_files',
+                'shell_path',
                 'default_php_version',
                 'virtual_hosts_directory',
                 'mail_domains_directory',
+                'borg_repositories_directory',
+                'description',
+                'record_usage_files',
                 'async_support_enabled',
                 'rabbitmq_username',
                 'rabbitmq_virtual_host_name',

--- a/src/Endpoints/UrlRedirects.php
+++ b/src/Endpoints/UrlRedirects.php
@@ -96,6 +96,7 @@ class UrlRedirects extends Endpoint
                 'keep_path',
                 'force_ssl',
                 'balancer_backend_name',
+                'description',
                 'cluster_id',
             ]));
 
@@ -150,6 +151,7 @@ class UrlRedirects extends Endpoint
                 'keep_path',
                 'force_ssl',
                 'balancer_backend_name',
+                'description',
                 'id',
                 'cluster_id',
             ]));

--- a/src/Models/UnixUser.php
+++ b/src/Models/UnixUser.php
@@ -17,6 +17,7 @@ class UnixUser extends ClusterModel implements Model
     private ?string $mailDomainsDirectory = null;
     private ?string $borgRepositoriesDirectory = null;
     private string $shellPath = ShellPath::BASH;
+    private bool $recordUsageFiles = false;
     private bool $asyncSupportEnabled = false;
     private ?string $rabbitMqUsername = null;
     private ?string $rabbitMqVirtualHostName = null;
@@ -133,6 +134,18 @@ class UnixUser extends ClusterModel implements Model
             ->validate();
 
         $this->shellPath = $shellPath;
+
+        return $this;
+    }
+
+    public function getRecordUsageFiles(): string
+    {
+        return $this->recordUsageFiles;
+    }
+
+    public function setRecordUsageFiles(bool $recordUsageFiles): UnixUser
+    {
+        $this->recordUsageFiles = $recordUsageFiles;
 
         return $this;
     }
@@ -274,6 +287,7 @@ class UnixUser extends ClusterModel implements Model
             ->setMailDomainsDirectory(Arr::get($data, 'mail_domains_directory'))
             ->setBorgRepositoriesDirectory(Arr::get($data, 'borg_repositories_directory'))
             ->setShellPath(Arr::get($data, 'shell_path', ShellPath::BASH))
+            ->setRecordUsageFiles(Arr::get($data, 'record_usage_files', false))
             ->setAsyncSupportEnabled(Arr::get($data, 'async_support_enabled', false))
             ->setRabbitMqUsername(Arr::get($data, 'rabbitmq_username'))
             ->setRabbitMqVirtualHostName(Arr::get($data, 'rabbitmq_virtual_host_name'))
@@ -296,6 +310,7 @@ class UnixUser extends ClusterModel implements Model
             'mail_domains_directory' => $this->getMailDomainsDirectory(),
             'borg_repositories_directory' => $this->getBorgRepositoriesDirectory(),
             'shell_path' => $this->getShellPath(),
+            'record_usage_files' => $this->getRecordUsageFiles(),
             'async_support_enabled' => $this->isAsyncSupportEnabled(),
             'rabbitmq_username' => $this->getRabbitMqUsername(),
             'rabbitmq_virtual_host_name' => $this->getRabbitMqVirtualHostName(),


### PR DESCRIPTION
# Changes

This PR adds the new attribute `record_usage_files` to UNIX users. It also adds missing attributes from create and update payloads for FPM pools, UNIX users and URL redirects.

Please ensure that tests are run, as they don't seem to be triggered for my fork.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
