### PR TITLE
Add callback url for deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.48.0]
+
+### Added
+
+- Add callback url for deployments.
+- Add callback url for the automatic deployments.
+
 ## [1.47.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ you won't be able to access the result of the deployment. Enable this behavior i
 
 ```php
 $configuration = new Configuration();
-$configuration->setAutoDeploy(); // Enable the auto deployment of affected clusters
+$configuration
+    ->setAutoDeploy() // Enable the auto deployment of affected clusters
+    ->setAutoDeployCallbackUrl(''); // Provide the callback url for automatic deployments
 
 // Initialize the client
 $client = new Client($configuration, true);
@@ -224,6 +226,8 @@ $api
     ->clusters()
     ->commit($clusterId);
 ```
+
+The commit method accepts a callback url as second parameter.
 
 ### Laravel
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -288,7 +288,12 @@ class Client implements ClientContract
             $deployment = (new Deployment())->setClusterId($affectedCluster);
 
             try {
-                $result = $clustersEndpoint->commit($affectedCluster);
+                $result = $clustersEndpoint->commit(
+                    $affectedCluster,
+                    $this
+                        ->configuration
+                        ->getAutoDeployCallbackUrl()
+                );
 
                 $deployment->setSuccess($result->isSuccess());
                 $result->isSuccess()

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.47.1';
+    private const VERSION = '1.48.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -13,6 +13,7 @@ class Configuration
     private ?string $accessToken;
     private bool $sandbox = false;
     private bool $autoDeploy = false;
+    private ?string $autoDeployCallbackUrl = null;
 
     public static function withCredentials(string $username, string $password, bool $sandbox = false): Configuration
     {
@@ -109,6 +110,18 @@ class Configuration
     public function setAutoDeploy(bool $autoDeploy = true): Configuration
     {
         $this->autoDeploy = $autoDeploy;
+
+        return $this;
+    }
+
+    public function getAutoDeployCallbackUrl(): ?string
+    {
+        return $this->autoDeployCallbackUrl;
+    }
+
+    public function setAutoDeployCallbackUrl(?string $autoDeployCallbackUrl): Configuration
+    {
+        $this->autoDeployCallbackUrl = $autoDeployCallbackUrl;
 
         return $this;
     }

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -7,6 +7,7 @@ use Vdhicts\Cyberfusion\ClusterApi\Models\Cluster;
 use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;
 use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Str;
 
 class Clusters extends Endpoint
 {
@@ -70,11 +71,16 @@ class Clusters extends Endpoint
      * @return Response
      * @throws RequestException
      */
-    public function commit(int $id): Response
+    public function commit(int $id, string $callbackUrl = null): Response
     {
+        $url = Str::optionalQueryParameters(
+            'cluster-deployments',
+            ['callback_url' => $callbackUrl]
+        );
+
         $request = (new Request())
             ->setMethod(Request::METHOD_POST)
-            ->setUrl('cluster-deployments')
+            ->setUrl($url)
             ->setBody([
                 'cluster_id' => $id,
             ]);


### PR DESCRIPTION
# Changes

_These changes aren't live in the Cluster API yet._

### Added

- Add callback url for deployments.
- Add callback url for the automatic deployments.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [ ] The supported Cluster API version is updated in the README (when applicable)
