### PR TITLE
Fix nodeId to be optional for the cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.48.1]
+
+### Fixed
+
+- Changed the `nodeId` property of the `Cron` model to optional.
+
 ## [1.48.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.48.0';
+    private const VERSION = '1.48.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/Cron.php
+++ b/src/Models/Cron.php
@@ -13,7 +13,7 @@ class Cron extends ClusterModel implements Model
     private ?string $emailAddress = null;
     private string $schedule;
     private int $unixUserId;
-    private int $nodeId;
+    private ?int $nodeId = null;
     private int $errorCount = 1;
     private int $randomDelayMaxSeconds = 10;
     private bool $lockingEnabled = true;
@@ -98,12 +98,12 @@ class Cron extends ClusterModel implements Model
         return $this;
     }
 
-    public function getNodeId(): int
+    public function getNodeId(): ?int
     {
         return $this->nodeId;
     }
 
-    public function setNodeId(int $nodeId): Cron
+    public function setNodeId(?int $nodeId): Cron
     {
         $this->nodeId = $nodeId;
 


### PR DESCRIPTION
# Changes

### Fixed

- Changed the `nodeId` property of the `Cron` model to optional.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
