### PR TITLE
Fix Laravel 9 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.49.2]
+
+### Fixed
+
+- Laravel 9 support failed due to using an old version of ramsey/uuid package to still support PHP 7.4. I intend to 
+  support PHP 7.4 until its EOL date (28 Nov 2022) when possible.
+
 ## [1.49.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This package is not created or maintained by Cyberfusion.
 
 ## Requirements
 
-This package requires PHP 7.4 or higher and uses Guzzle.
+This package requires PHP 7.4 or higher and uses Guzzle. I intend to support PHP 7.4 until its EOL date (28 Nov 2022) 
+when possible.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "illuminate/support": "^8.22 || ^9.0",
         "nesbot/carbon": "^2.43",
-        "ramsey/uuid": "^3.9",
+        "ramsey/uuid": "^3.9 || ^4.0",
         "vdhicts/http-query-builder": "^1.0"
     },
     "require-dev": {

--- a/tests/Support/ValidatorTest.php
+++ b/tests/Support/ValidatorTest.php
@@ -4,6 +4,7 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Tests\Support;
 
 use PHPUnit\Framework\TestCase;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\ValidationException;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Str;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 
 class ValidatorTest extends TestCase
@@ -158,6 +159,19 @@ class ValidatorTest extends TestCase
         $this->expectException(ValidationException::class);
         Validator::value('foo')
             ->email()
+            ->validate();
+    }
+
+    public function testUuid()
+    {
+        $result = Validator::value(Str::uuid())
+            ->uuid()
+            ->validate();
+        $this->assertTrue($result);
+
+        $this->expectException(ValidationException::class);
+        Validator::value('foo')
+            ->uuid()
             ->validate();
     }
 }


### PR DESCRIPTION
# Changes

### Fixed

- Laravel 9 support failed due to using an old version of ramsey/uuid package to still support PHP 7.4. I intend to 
  support PHP 7.4 until its EOL date (28 Nov 2022) when possible.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
