### PR TITLE
Expect multiple task results from the task collection results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.49.3]
+
+### Fixed
+
+- After talking to @WilliamDEdwards the task collection works a bit different then I thought. In short: a task 
+  collection contains at least 2 task and always returns the results of all those tasks. Updated the endpoint to reflect
+  that setup. The official documentation will be improved to provide more information about task collections and the 
+  results.
+
 ## [1.49.2]
 
 ### Fixed

--- a/src/Endpoints/TaskCollections.php
+++ b/src/Endpoints/TaskCollections.php
@@ -28,7 +28,12 @@ class TaskCollections extends Endpoint
         }
 
         return $response->setData([
-            'taskResult' => (new TaskResult())->fromArray($response->getData()),
+            'taskResults' => array_map(
+                function (array $data) {
+                    return (new TaskResult())->fromArray($data);
+                },
+                $response->getData()
+            ),
         ]);
     }
 }


### PR DESCRIPTION
# Changes

### Fixed

- After talking to @WilliamDEdwards the task collection works a bit different then I thought. In short: a task 
  collection contains at least 2 task and always returns the results of all those tasks. Updated the endpoint to reflect
  that setup. The official documentation will be improved to provide more information about task collections and the 
  results.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
