### PR TITLE
Version 1.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.50.0]
+
+### Added
+
+- Add Borg archive download endpoint.
+
+### Changed
+
+- Fix capitalisation of Enum values of `PassengerAppTypeEnum` and `PassengerEnvironmentEnum`.
+- Update to [API version 1.119](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.119-2022-04-26).
+
 ## [1.49.3]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package is build and tested on the **1.118** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.119** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.49.0';
+    private const VERSION = '1.50.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/BorgArchives.php
+++ b/src/Endpoints/BorgArchives.php
@@ -211,6 +211,37 @@ class BorgArchives extends Endpoint
 
     /**
      * @param int $id
+     * @param string|null $callbackUrl
+     * @return Response
+     * @throws RequestException
+     */
+    public function download(int $id, string $callbackUrl = null): Response
+    {
+        $url = Str::optionalQueryParameters(
+            sprintf('borg-archives/%d/download', $id),
+            ['callback_url' => $callbackUrl]
+        );
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl($url);
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $taskCollection = (new TaskCollection())->fromArray($response->getData());
+
+        return $response->setData([
+            'taskCollection' => $taskCollection,
+        ]);
+    }
+
+    /**
+     * @param int $id
      * @return Response
      * @throws RequestException
      */

--- a/src/Enums/PassengerAppType.php
+++ b/src/Enums/PassengerAppType.php
@@ -4,7 +4,7 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
 
 class PassengerAppType
 {
-    public const NODEJS = 'nodejs';
+    public const NODEJS = 'NodeJS';
 
     public const AVAILABLE = [
         self::NODEJS,

--- a/src/Enums/PassengerEnvironment.php
+++ b/src/Enums/PassengerEnvironment.php
@@ -4,8 +4,8 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
 
 class PassengerEnvironment
 {
-    public const PRODUCTION = 'production';
-    public const DEVELOPMENT = 'development';
+    public const PRODUCTION = 'Production';
+    public const DEVELOPMENT = 'Development';
 
     public const AVAILABLE = [
         self::PRODUCTION,


### PR DESCRIPTION
# Changes

This PR updates the library to support Cluster API version 1.119.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
