### PR TITLE
Version 1.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.51.0]
+
+### Added
+
+- Add `path` to Borg archive contents, restore and download requests.
+
 ## [1.50.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company 
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.119** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.121.1** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.50.0';
+    private const VERSION = '1.51.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/BorgArchives.php
+++ b/src/Endpoints/BorgArchives.php
@@ -184,11 +184,11 @@ class BorgArchives extends Endpoint
      * @return Response
      * @throws RequestException
      */
-    public function restore(int $id, string $callbackUrl = null): Response
+    public function restore(int $id, string $path = null, string $callbackUrl = null): Response
     {
         $url = Str::optionalQueryParameters(
             sprintf('borg-archives/%d/restore', $id),
-            ['callback_url' => $callbackUrl]
+            ['path' => $path, 'callback_url' => $callbackUrl]
         );
 
         $request = (new Request())
@@ -215,11 +215,11 @@ class BorgArchives extends Endpoint
      * @return Response
      * @throws RequestException
      */
-    public function download(int $id, string $callbackUrl = null): Response
+    public function download(int $id, string $path = null, string $callbackUrl = null): Response
     {
         $url = Str::optionalQueryParameters(
             sprintf('borg-archives/%d/download', $id),
-            ['callback_url' => $callbackUrl]
+            ['path' => $path, 'callback_url' => $callbackUrl]
         );
 
         $request = (new Request())
@@ -245,11 +245,16 @@ class BorgArchives extends Endpoint
      * @return Response
      * @throws RequestException
      */
-    public function contents(int $id): Response
+    public function contents(int $id, string $path = null): Response
     {
+        $url = Str::optionalQueryParameters(
+            sprintf('borg-archives/%d/contents', $id),
+            ['path' => $path]
+        );
+
         $request = (new Request())
             ->setMethod(Request::METHOD_GET)
-            ->setUrl(sprintf('borg-archives/%d/contents', $id));
+            ->setUrl($url);
 
         $response = $this
             ->client


### PR DESCRIPTION
# Changes

- Add new path query parameter to download
- Add new path query parameter to restore
- Add missing path query parameter to contents

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
