### PR TITLE
Update to API version 1.124.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.54.0]
+
+### Changed
+
+- Change validation of `startup_file` of `PassengerApp` to end with `.js`
+- Update to [API version 1.124.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.124.1-2022-05-21).
+
 ## [1.53.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.124** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.124.1** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.53.0';
+    private const VERSION = '1.54.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/PassengerApp.php
+++ b/src/Models/PassengerApp.php
@@ -200,7 +200,7 @@ class PassengerApp extends ClusterModel implements Model
     {
         Validator::value($startupFile)
             ->maxLength(255)
-            ->pattern('^([a-zA-Z0-9-_.]+)(.js)$')
+            ->endsWith('.js')
             ->validate();
 
         $this->startupFile = $startupFile;

--- a/src/Support/Validator.php
+++ b/src/Support/Validator.php
@@ -18,6 +18,7 @@ class Validator
     private const IP = 'ip';
     private const EMAIL = 'email';
     private const UUID = 'uuid';
+    private const ENDS_WITH = 'ends_with';
 
     /** @var mixed */
     private $value;
@@ -105,6 +106,12 @@ class Validator
         return $this;
     }
 
+    public function endsWith(string $needle): self
+    {
+        $this->validations[self::ENDS_WITH] = $needle;
+        return $this;
+    }
+
     private function isNullable(): bool
     {
         return Arr::has($this->validations, self::NULLABLE);
@@ -137,6 +144,8 @@ class Validator
                 return filter_var($this->value, FILTER_VALIDATE_EMAIL) !== false;
             case self::UUID:
                 return Uuid::isValid($this->value);
+            case self::ENDS_WITH:
+                return is_string($this->value) && Str::endsWith($this->value, $setting);
             default:
                 return true;
         }

--- a/tests/Support/ValidatorTest.php
+++ b/tests/Support/ValidatorTest.php
@@ -174,4 +174,17 @@ class ValidatorTest extends TestCase
             ->uuid()
             ->validate();
     }
+
+    public function testEndsWith()
+    {
+        $result = Validator::value('test.js')
+            ->endsWith('.js')
+            ->validate();
+        $this->assertTrue($result);
+
+        $this->expectException(ValidationException::class);
+        Validator::value(2)
+            ->endsWith('.js')
+            ->validate();
+    }
 }


### PR DESCRIPTION
# Changes

- Change validation of `startup_file` of `PassengerApp` to end with `.js`
- Update to [API version 1.124.1](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.124.1-2022-05-21).

Closes #120 

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
