### PR TITLE
Version 1.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.57.0]
+
+### Changed
+
+- Use `DatabaseUserGrantPrivilegeName` enum for database user grant privilege names.
+- Make new `SELECT` database user grant privilege name available.
+- Update to [API version 1.127](https://cluster-api.cyberfusion.nl/redoc#section/Changelog/1.127-2022-06-06).
+
 ## [1.56.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.126.1** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.127** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.56.0';
+    private const VERSION = '1.57.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Enums/DatabaseUserGrantPrivilegeName.php
+++ b/src/Enums/DatabaseUserGrantPrivilegeName.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class DatabaseUserGrantPrivilegeName
+{
+    public const ALL = 'ALL';
+    public const SELECT = 'SELECT';
+
+    public const DEFAULT = self::ALL;
+
+    public const AVAILABLE = [
+        self::ALL,
+        self::SELECT,
+    ];
+}

--- a/src/Models/DatabaseUserGrant.php
+++ b/src/Models/DatabaseUserGrant.php
@@ -5,15 +5,14 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\DatabaseUserGrantPrivilegeName;
 
 class DatabaseUserGrant extends ClusterModel implements Model
 {
-    public const DEFAULT_PRIVILEGE_NAME = 'ALL';
-
     private int $databaseId;
     private int $databaseUserId;
     private ?string $tableName = null;
-    private string $privilegeName = self::DEFAULT_PRIVILEGE_NAME;
+    private string $privilegeName = DatabaseUserGrantPrivilegeName::ALL;
     private ?int $id = null;
     private ?int $clusterId = null;
     private ?string $createdAt = null;
@@ -68,6 +67,10 @@ class DatabaseUserGrant extends ClusterModel implements Model
 
     public function setPrivilegeName(string $privilegeName): DatabaseUserGrant
     {
+        Validator::value($privilegeName)
+            ->valueIn(DatabaseUserGrantPrivilegeName::AVAILABLE)
+            ->validate();
+
         $this->privilegeName = $privilegeName;
 
         return $this;
@@ -127,7 +130,7 @@ class DatabaseUserGrant extends ClusterModel implements Model
             ->setDatabaseId(Arr::get($data, 'database_id'))
             ->setDatabaseUserId(Arr::get($data, 'database_user_id'))
             ->setTableName(Arr::get($data, 'table_name'))
-            ->setPrivilegeName(Arr::get($data, 'privilege_name', self::DEFAULT_PRIVILEGE_NAME))
+            ->setPrivilegeName(Arr::get($data, 'privilege_name', DatabaseUserGrantPrivilegeName::ALL))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
             ->setCreatedAt(Arr::get($data, 'created_at'))


### PR DESCRIPTION
# Changes

Add new `DatabaseUserGrantPrivilegeName` enum with new `SELECT` database user grant privilege name.

`DEFAULT_PRIVILEGE_NAME` has been removed in favour of the enum, but the default value for `privilegeName` remains the same.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
