### PR TITLE
Small cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ detailed information.
 ### Removed
 
 - Remove unused imports.
-- Remove `sprintf` calls without parameter.
+- Remove `sprintf` calls without parameters.
 
 ## [1.57.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## Unreleased
+
+### Changed
+
+- Update docblocks.
+
+### Removed
+
+- Remove unused imports.
+- Remove `sprintf` calls without parameter.
+
 ## [1.57.0]
 
 ### Changed

--- a/src/Endpoints/BorgArchives.php
+++ b/src/Endpoints/BorgArchives.php
@@ -85,7 +85,7 @@ class BorgArchives extends Endpoint
         ]);
 
         $url = Str::optionalQueryParameters(
-            sprintf('borg-archives/database'),
+            'borg-archives/database',
             ['callback_url' => $callbackUrl]
         );
 
@@ -127,7 +127,7 @@ class BorgArchives extends Endpoint
         ]);
 
         $url = Str::optionalQueryParameters(
-            sprintf('borg-archives/unix-user'),
+            'borg-archives/unix-user',
             ['callback_url' => $callbackUrl]
         );
 
@@ -180,6 +180,7 @@ class BorgArchives extends Endpoint
 
     /**
      * @param int $id
+     * @param string|null $path
      * @param string|null $callbackUrl
      * @return Response
      * @throws RequestException
@@ -211,6 +212,7 @@ class BorgArchives extends Endpoint
 
     /**
      * @param int $id
+     * @param string|null $path
      * @param string|null $callbackUrl
      * @return Response
      * @throws RequestException
@@ -242,6 +244,7 @@ class BorgArchives extends Endpoint
 
     /**
      * @param int $id
+     * @param string|null $path
      * @return Response
      * @throws RequestException
      */

--- a/src/Endpoints/BorgRepositories.php
+++ b/src/Endpoints/BorgRepositories.php
@@ -2,8 +2,6 @@
 
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
-use DateTimeInterface;
-use Vdhicts\Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\BorgRepository;
 use Vdhicts\Cyberfusion\ClusterApi\Models\TaskCollection;

--- a/src/Endpoints/Clusters.php
+++ b/src/Endpoints/Clusters.php
@@ -69,6 +69,7 @@ class Clusters extends Endpoint
 
     /**
      * @param int $id
+     * @param string|null $callbackUrl
      * @return Response
      * @throws RequestException
      */

--- a/src/Endpoints/PassengerApps.php
+++ b/src/Endpoints/PassengerApps.php
@@ -4,11 +4,9 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\PassengerApp;
-use Vdhicts\Cyberfusion\ClusterApi\Models\TaskCollection;
 use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;
 use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
-use Vdhicts\Cyberfusion\ClusterApi\Support\Str;
 
 class PassengerApps extends Endpoint
 {


### PR DESCRIPTION
# Changes

Just a tiny cleanup that doesn't require a separate release, so no version bump here as this should be released with the following change.

### Changed

- Update docblocks.

### Removed

- Remove unused imports.
- Remove `sprintf` calls without parameters.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
