### PR TITLE
Update to API version 1.128.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ detailed information.
 
 ## Unreleased
 
+## [1.58.0]
+
+### Added
+
+- Add database comparison endpoint.
+
 ### Changed
 
 - Update docblocks.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.127** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.128.1** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.57.0';
+    private const VERSION = '1.58.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -6,6 +6,7 @@ use DateTimeInterface;
 use Vdhicts\Cyberfusion\ClusterApi\Enums\TimeUnit;
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\Database;
+use Vdhicts\Cyberfusion\ClusterApi\Models\DatabaseComparison;
 use Vdhicts\Cyberfusion\ClusterApi\Models\DatabaseUsage;
 use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;
@@ -175,6 +176,36 @@ class Databases extends Endpoint
                     $response->getData()
                 )
                 : null,
+        ]);
+    }
+
+    /**
+     * @param int $leftDatabaseId
+     * @param int $rightDatabaseId
+     * @return Response
+     * @throws RequestException
+     */
+    public function compareTo(int $leftDatabaseId, int $rightDatabaseId): Response
+    {
+        $url = sprintf(
+            'databases/%d/comparison?right_database_id=%d',
+            $leftDatabaseId,
+            $rightDatabaseId
+        );
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl($url);
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'databaseComparison' => (new DatabaseComparison())->fromArray($response->getData()),
         ]);
     }
 }

--- a/src/Models/DatabaseComparison.php
+++ b/src/Models/DatabaseComparison.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+
+class DatabaseComparison extends ClusterModel implements Model
+{
+    private array $identicalTablesNames = [];
+    private array $notIdenticalTablesNames = [];
+    private array $onlyLeftTablesNames = [];
+    private array $onlyRightTablesNames = [];
+
+    /**
+     * These tables exist in the left and right databases, and their structure and contents are identical.
+     */
+    public function getIdenticalTablesNames(): array
+    {
+        return $this->identicalTablesNames;
+    }
+
+    public function setIdenticalTablesNames(array $identicalTablesNames): DatabaseComparison
+    {
+        $this->identicalTablesNames = $identicalTablesNames;
+
+        return $this;
+    }
+
+    /**
+     * These tables exist in the left and right databases, but their structure and/or contents are not identical.
+     */
+    public function getNotIdenticalTablesNames(): array
+    {
+        return $this->notIdenticalTablesNames;
+    }
+
+    public function setNotIdenticalTablesNames(array $notIdenticalTablesNames): DatabaseComparison
+    {
+        $this->notIdenticalTablesNames = $notIdenticalTablesNames;
+
+        return $this;
+    }
+
+    /**
+     * These tables only exist in the left database.
+     */
+    public function getOnlyLeftTablesNames(): array
+    {
+        return $this->onlyLeftTablesNames;
+    }
+
+    public function setOnlyLeftTablesNames(array $onlyLeftTablesNames): DatabaseComparison
+    {
+        $this->onlyLeftTablesNames = $onlyLeftTablesNames;
+
+        return $this;
+    }
+
+    /**
+     * These tables only exist in the right database.
+     */
+    public function getOnlyRightTablesNames(): array
+    {
+        return $this->onlyRightTablesNames;
+    }
+
+    public function setOnlyRightTablesNames(array $onlyRightTablesNames): DatabaseComparison
+    {
+        $this->onlyRightTablesNames = $onlyRightTablesNames;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): DatabaseComparison
+    {
+        return $this
+            ->setIdenticalTablesNames(Arr::get($data, 'identical_tables_names', []))
+            ->setNotIdenticalTablesNames(Arr::get($data, 'not_identical_tables_names', []))
+            ->setOnlyLeftTablesNames(Arr::get($data, 'only_left_tables_names', []))
+            ->setOnlyRightTablesNames(Arr::get($data, 'only_right_tables_names', []));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'identical_tables_names' => $this->getIdenticalTablesNames(),
+            'not_identical_tables_names' => $this->getNotIdenticalTablesNames(),
+            'only_left_tables_names' => $this->getOnlyLeftTablesNames(),
+            'only_right_tables_names' => $this->getOnlyRightTablesNames(),
+        ];
+    }
+}


### PR DESCRIPTION
# Changes

Closes #126 

### Added

- Add database comparison endpoint.

### Changed

- Update docblocks.

### Removed

- Remove unused imports.
- Remove `sprintf` calls without parameters.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
