### PR TITLE
Version 1.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
-## Unreleased
+## [1.59.0]
+
+### Added
+
+- Add the `domainRoot` attribute to virtual host.
 
 ## [1.58.0]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.128.1** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.129** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.58.0';
+    private const VERSION = '1.59.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Models/VirtualHost.php
+++ b/src/Models/VirtualHost.php
@@ -20,6 +20,7 @@ class VirtualHost extends ClusterModel implements Model
     private bool $forceSsl = true;
     private ?string $customConfig = null;
     private ?string $balancerBackendName = null;
+    private ?string $domainRoot = null;
     private array $deployCommands = [];
     private array $allowOverrideDirectives = AllowOverrideDirectives::DEFAULTS;
     private array $allowOverrideOptionDirectives = AllowOverrideOptionDirectives::DEFAULTS;
@@ -163,6 +164,18 @@ class VirtualHost extends ClusterModel implements Model
         return $this;
     }
 
+    public function getDomainRoot(): ?string
+    {
+        return $this->domainRoot;
+    }
+
+    public function setDomainRoot(?string $domainRoot): VirtualHost
+    {
+        $this->domainRoot = $domainRoot;
+
+        return $this;
+    }
+
     public function getDeployCommands(): array
     {
         return $this->deployCommands;
@@ -269,6 +282,7 @@ class VirtualHost extends ClusterModel implements Model
             ->setPassengerAppId(Arr::get($data, 'passenger_app_id'))
             ->setForceSsl(Arr::get($data, 'force_ssl'))
             ->setBalancerBackendName(Arr::get($data, 'balancer_backend_name'))
+            ->setDomainRoot(Arr::get($data, 'domain_root'))
             ->setCustomConfig(Arr::get($data, 'custom_config'))
             ->setDeployCommands(Arr::get($data, 'deploy_commands', []))
             ->setAllowOverrideDirectives(Arr::get($data, 'allow_override_directives', AllowOverrideDirectives::DEFAULTS))
@@ -294,6 +308,7 @@ class VirtualHost extends ClusterModel implements Model
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),
             'balancer_backend_name' => $this->getBalancerBackendName(),
+            'domain_root' => $this->getDomainRoot(),
             'deploy_commands' => $this->getDeployCommands(),
             'allow_override_directives' => $this->getAllowOverrideDirectives(),
             'allow_override_option_directives' => $this->getAllowOverrideOptionDirectives(),


### PR DESCRIPTION
# Changes

Add the `domainRoot` attribute to virtual host.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
