### PR TITLE
Version 1.63.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.63.0]
+
+### Added
+
+- Add Borg repository archives metadata endpoint.
+- Borg archive metadata now has its own model, `BorgArchiveMetadata`.
+
 ## [1.62.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.132** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.133** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.62.0';
+    private const VERSION = '1.63.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/BorgArchives.php
+++ b/src/Endpoints/BorgArchives.php
@@ -11,6 +11,7 @@ use Vdhicts\Cyberfusion\ClusterApi\Support\Str;
 use Vdhicts\Cyberfusion\ClusterApi\Models\BorgArchiveDatabaseCreation;
 use Vdhicts\Cyberfusion\ClusterApi\Models\BorgArchiveUnixUserCreation;
 use Vdhicts\Cyberfusion\ClusterApi\Models\BorgArchiveContent;
+use Vdhicts\Cyberfusion\ClusterApi\Models\BorgArchiveMetadata;
 use Vdhicts\Cyberfusion\ClusterApi\Models\TaskCollection;
 
 class BorgArchives extends Endpoint
@@ -173,8 +174,7 @@ class BorgArchives extends Endpoint
         }
 
         return $response->setData([
-            'contents_path' => $response->getData('contents_path'),
-            'exists_on_server' => $response->getData('exists_on_server'),
+            'borgArchiveMetadata' => (new BorgArchiveMetadata())->fromArray($response->getData()),
         ]);
     }
 

--- a/src/Endpoints/BorgRepositories.php
+++ b/src/Endpoints/BorgRepositories.php
@@ -4,6 +4,7 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
 use Vdhicts\Cyberfusion\ClusterApi\Models\BorgRepository;
+use Vdhicts\Cyberfusion\ClusterApi\Models\BorgArchiveMetadata;
 use Vdhicts\Cyberfusion\ClusterApi\Models\TaskCollection;
 use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;
@@ -268,6 +269,34 @@ class BorgRepositories extends Endpoint
 
         return $response->setData([
             'taskCollection' => $taskCollection,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function archivesMetadata(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('borg-repositories/%d/archives-metadata', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'metadata' => array_map(
+                function (array $data) {
+                    return (new BorgArchiveMetadata())->fromArray($data);
+                },
+                $response->getData()
+            ),
         ]);
     }
 }

--- a/src/Models/BorgArchiveMetadata.php
+++ b/src/Models/BorgArchiveMetadata.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+
+class BorgArchiveMetadata extends ClusterModel implements Model
+{
+    private string $contentsPath;
+    private bool $existsOnServer;
+    private int $borgArchiveId;
+
+    public function getContentsPath(): string
+    {
+        return $this->contentsPath;
+    }
+
+    public function setContentsPath(string $contentsPath): BorgArchiveMetadata
+    {
+        $this->contentsPath = $contentsPath;
+
+        return $this;
+    }
+
+    public function getExistsOnServer(): bool
+    {
+        return $this->existsOnServer;
+    }
+
+    public function setExistsOnServer(bool $existsOnServer): BorgArchiveMetadata
+    {
+        $this->existsOnServer = $existsOnServer;
+
+        return $this;
+    }
+
+    public function getBorgArchiveId(): int
+    {
+        return $this->borgArchiveId;
+    }
+
+    public function setBorgArchiveId(int $borgArchiveId): BorgArchiveMetadata
+    {
+        $this->borgArchiveId = $borgArchiveId;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): BorgArchiveMetadata
+    {
+        return $this
+            ->setContentsPath(Arr::get($data, 'contents_path'))
+            ->setExistsOnServer(Arr::get($data, 'exists_on_server'))
+            ->setBorgArchiveId(Arr::get($data, 'borg_archive_id'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'contents_path' => $this->getContentsPath(),
+            'exists_on_server' => $this->getExistsOnServer(),
+            'borg_archive_id' => $this->getBorgArchiveId(),
+        ];
+    }
+}


### PR DESCRIPTION
# Changes

- Add Borg repository archives metadata endpoint.
- Borg archive metadata now has its own model, `BorgArchiveMetadata`.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
