### PR TITLE
Version 1.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ detailed information.
 - Add htpasswd users endpoint.
 - Add basic authentication realms endpoints.
 - Add CMS update option endpoint.
+- Add CMS update configuration constant endpoint.
 
 ## [1.64.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.65.0]
+
+### Added
+
+- Add htpasswd files endpoint.
+- Add htpasswd users endpoint.
+- Add basic authentication realms endpoints.
+- Add CMS update option endpoint.
+
 ## [1.64.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.137.1** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.138** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.134** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.137.1** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.64.0';
+    private const VERSION = '1.65.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -74,6 +74,11 @@ class ClusterApi
         return new Endpoints\HtpasswdFiles($this->client);
     }
 
+    public function htpasswdUsers(): Endpoints\HtpasswdUsers
+    {
+        return new Endpoints\HtpasswdUsers($this->client);
+    }
+
     public function health(): Endpoints\Health
     {
         return new Endpoints\Health($this->client);

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -69,6 +69,11 @@ class ClusterApi
         return new Endpoints\FpmPools($this->client);
     }
 
+    public function htpasswdFiles(): Endpoints\HtpasswdFiles
+    {
+        return new Endpoints\HtpasswdFiles($this->client);
+    }
+
     public function health(): Endpoints\Health
     {
         return new Endpoints\Health($this->client);

--- a/src/ClusterApi.php
+++ b/src/ClusterApi.php
@@ -49,6 +49,11 @@ class ClusterApi
         return new Endpoints\Crons($this->client);
     }
 
+    public function basicAuthenticationRealms(): Endpoints\BasicAuthenticationRealms
+    {
+        return new Endpoints\BasicAuthenticationRealms($this->client);
+    }
+
     public function databases(): Endpoints\Databases
     {
         return new Endpoints\Databases($this->client);

--- a/src/Endpoints/BasicAuthenticationRealms.php
+++ b/src/Endpoints/BasicAuthenticationRealms.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\BasicAuthenticationRealm;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+
+class BasicAuthenticationRealms extends Endpoint
+{
+    /**
+     * @param ListFilter|null $filter
+     * @return Response
+     * @throws RequestException
+     */
+    public function list(ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('basic-authentication-realms?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'basicAuthenticationRealms' => array_map(
+                function (array $data) {
+                    return (new BasicAuthenticationRealm())->fromArray($data);
+                },
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('basic-authentication-realms/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'basicAuthenticationRealm' => (new BasicAuthenticationRealm())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param BasicAuthenticationRealm $basicAuthenticationRealm
+     * @return Response
+     * @throws RequestException
+     */
+    public function create(BasicAuthenticationRealm $basicAuthenticationRealm): Response
+    {
+        $this->validateRequired($basicAuthenticationRealm, 'create', [
+            'name',
+            'directory_path',
+            'htpasswd_file_id',
+            'virtual_host_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('basic-authentication-realms')
+            ->setBody($this->filterFields($basicAuthenticationRealm->toArray(), [
+                'name',
+                'directory_path',
+                'htpasswd_file_id',
+                'virtual_host_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $basicAuthenticationRealm = (new BasicAuthenticationRealm())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($basicAuthenticationRealm->getClusterId());
+
+        return $response->setData([
+            'basicAuthenticationRealm' => $basicAuthenticationRealm,
+        ]);
+    }
+
+    /**
+     * @param BasicAuthenticationRealm $basicAuthenticationRealm
+     * @return Response
+     * @throws RequestException
+     */
+    public function update(BasicAuthenticationRealm $basicAuthenticationRealm): Response
+    {
+        $this->validateRequired($basicAuthenticationRealm, 'update', [
+            'name',
+            'directory_path',
+            'htpasswd_file_id',
+            'virtual_host_id',
+            'id',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('basic-authentication-realms/%d', $basicAuthenticationRealm->getId()))
+            ->setBody($this->filterFields($basicAuthenticationRealm->toArray(), [
+                'name',
+                'directory_path',
+                'htpasswd_file_id',
+                'virtual_host_id',
+                'id',
+                'cluster_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $basicAuthenticationRealm = (new BasicAuthenticationRealm())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($basicAuthenticationRealm->getClusterId());
+
+        return $response->setData([
+            'basicAuthenticationRealm' => $basicAuthenticationRealm,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        // Log the affected cluster by retrieving the model first
+        $result = $this->get($id);
+        if ($result->isSuccess()) {
+            $clusterId = $result
+                ->getData('basicAuthenticationRealm')
+                ->getClusterId();
+
+            $this
+                ->client
+                ->addAffectedCluster($clusterId);
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('basic-authentication-realms/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Endpoints/Cmses.php
+++ b/src/Endpoints/Cmses.php
@@ -3,7 +3,6 @@
 namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
 
 use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
-use Vdhicts\Cyberfusion\ClusterApi\Enums\CmsOptionName;
 use Vdhicts\Cyberfusion\ClusterApi\Models\Cms;
 use Vdhicts\Cyberfusion\ClusterApi\Models\CmsOption;
 use Vdhicts\Cyberfusion\ClusterApi\Models\CmsInstallation;
@@ -12,7 +11,6 @@ use Vdhicts\Cyberfusion\ClusterApi\Request;
 use Vdhicts\Cyberfusion\ClusterApi\Response;
 use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
 use Vdhicts\Cyberfusion\ClusterApi\Support\Str;
-use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
 
 class Cmses extends Endpoint
 {
@@ -237,25 +235,22 @@ class Cmses extends Endpoint
 
     /**
      * @param int $id
-     * @param string $cmsOptionName
      * @param CmsOption $cmsOption
      * @return Response
      * @throws RequestException
      */
-    public function updateOption(int $id, string $cmsOptionName, CmsOption $cmsOption): Response
+    public function updateOption(int $id, CmsOption $cmsOption): Response
     {
         $this->validateRequired($cmsOption, 'update', [
+            'name',
             'value',
         ]);
 
-        Validator::value($cmsOptionName)
-            ->valueIn(CmsOptionName::AVAILABLE)
-            ->validate();
-
         $request = (new Request())
             ->setMethod(Request::METHOD_PUT)
-            ->setUrl(sprintf('cmses/%d/options/%d', $id, $cmsOptionName))
+            ->setUrl(sprintf('cmses/%d/options/%d', $id, $cmsOption->getName()))
             ->setBody($this->filterFields($cmsOption->toArray(), [
+                'name',
                 'value',
             ]));
 

--- a/src/Endpoints/HtpasswdFiles.php
+++ b/src/Endpoints/HtpasswdFiles.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\HtpasswdFile;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+
+class HtpasswdFiles extends Endpoint
+{
+    /**
+     * @param ListFilter|null $filter
+     * @return Response
+     * @throws RequestException
+     */
+    public function list(ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('htpasswd-files?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'htpasswdFiles' => array_map(
+                function (array $data) {
+                    return (new HtpasswdFile())->fromArray($data);
+                },
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('htpasswd-files/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'htpasswdFile' => (new HtpasswdFile())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param HtpasswdFile $htpasswdFile
+     * @return Response
+     * @throws RequestException
+     */
+    public function create(HtpasswdFile $htpasswdFile): Response
+    {
+        $this->validateRequired($htpasswdFile, 'create', [
+            'unix_user_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('htpasswd-files')
+            ->setBody($this->filterFields($htpasswdFile->toArray(), [
+                'unix_user_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $htpasswdFile = (new HtpasswdFile())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($htpasswdFile->getClusterId());
+
+        return $response->setData([
+            'htpasswdFile' => $htpasswdFile,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        // Log the affected cluster by retrieving the model first
+        $result = $this->get($id);
+        if ($result->isSuccess()) {
+            $clusterId = $result
+                ->getData('htpasswdFile')
+                ->getClusterId();
+
+            $this
+                ->client
+                ->addAffectedCluster($clusterId);
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('htpasswd-files/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Endpoints/HtpasswdUsers.php
+++ b/src/Endpoints/HtpasswdUsers.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Endpoints;
+
+use Vdhicts\Cyberfusion\ClusterApi\Exceptions\RequestException;
+use Vdhicts\Cyberfusion\ClusterApi\Models\HtpasswdUser;
+use Vdhicts\Cyberfusion\ClusterApi\Request;
+use Vdhicts\Cyberfusion\ClusterApi\Response;
+use Vdhicts\Cyberfusion\ClusterApi\Support\ListFilter;
+
+class HtpasswdUsers extends Endpoint
+{
+    /**
+     * @param ListFilter|null $filter
+     * @return Response
+     * @throws RequestException
+     */
+    public function list(ListFilter $filter = null): Response
+    {
+        if (is_null($filter)) {
+            $filter = new ListFilter();
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('htpasswd-users?%s', $filter->toQuery()));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'htpasswdUsers' => array_map(
+                function (array $data) {
+                    return (new HtpasswdUser())->fromArray($data);
+                },
+                $response->getData()
+            ),
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function get(int $id): Response
+    {
+        $request = (new Request())
+            ->setMethod(Request::METHOD_GET)
+            ->setUrl(sprintf('htpasswd-users/%d', $id));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        return $response->setData([
+            'htpasswdUser' => (new HtpasswdUser())->fromArray($response->getData()),
+        ]);
+    }
+
+    /**
+     * @param HtpasswdUser $htpasswdUser
+     * @return Response
+     * @throws RequestException
+     */
+    public function create(HtpasswdUser $htpasswdUser): Response
+    {
+        $this->validateRequired($htpasswdUser, 'create', [
+            'username',
+            'password',
+            'htpasswd_file_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_POST)
+            ->setUrl('htpasswd-users')
+            ->setBody($this->filterFields($htpasswdUser->toArray(), [
+                'username',
+                'password',
+                'htpasswd_file_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $htpasswdUser = (new HtpasswdUser())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($htpasswdUser->getClusterId());
+
+        return $response->setData([
+            'htpasswdUser' => $htpasswdUser,
+        ]);
+    }
+
+    /**
+     * @param HtpasswdUser $htpasswdUser
+     * @return Response
+     * @throws RequestException
+     */
+    public function update(HtpasswdUser $htpasswdUser): Response
+    {
+        $this->validateRequired($htpasswdUser, 'update', [
+            'username',
+            'password',
+            'htpasswd_file_id',
+            'id',
+            'cluster_id',
+        ]);
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_PUT)
+            ->setUrl(sprintf('htpasswd-users/%d', $htpasswdUser->getId()))
+            ->setBody($this->filterFields($htpasswdUser->toArray(), [
+                'username',
+                'password',
+                'htpasswd_file_id',
+                'id',
+                'cluster_id',
+            ]));
+
+        $response = $this
+            ->client
+            ->request($request);
+        if (!$response->isSuccess()) {
+            return $response;
+        }
+
+        $htpasswdUser = (new HtpasswdUser())->fromArray($response->getData());
+
+        // Log which cluster is affected by this change
+        $this
+            ->client
+            ->addAffectedCluster($htpasswdUser->getClusterId());
+
+        return $response->setData([
+            'htpasswdUser' => $htpasswdUser,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @return Response
+     * @throws RequestException
+     */
+    public function delete(int $id): Response
+    {
+        // Log the affected cluster by retrieving the model first
+        $result = $this->get($id);
+        if ($result->isSuccess()) {
+            $clusterId = $result
+                ->getData('htpasswdUser')
+                ->getClusterId();
+
+            $this
+                ->client
+                ->addAffectedCluster($clusterId);
+        }
+
+        $request = (new Request())
+            ->setMethod(Request::METHOD_DELETE)
+            ->setUrl(sprintf('htpasswd-users/%d', $id));
+
+        return $this
+            ->client
+            ->request($request);
+    }
+}

--- a/src/Enums/CmsConfigurationConstantName.php
+++ b/src/Enums/CmsConfigurationConstantName.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class CmsConfigurationConstantName
+{
+    public const DB_NAME = 'DB_NAME';
+    public const DB_USER = 'DB_USER';
+    public const DB_PASSWORD = 'DB_PASSWORD';
+    public const DB_HOST = 'DB_HOST';
+
+    public const AVAILABLE = [
+        self::DB_NAME,
+        self::DB_USER,
+        self::DB_PASSWORD,
+        self::DB_HOST,
+    ];
+}

--- a/src/Enums/CmsOptionName.php
+++ b/src/Enums/CmsOptionName.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Enums;
+
+class CmsOptionName
+{
+    public const BLOG_PUBLIC = 'blog_public';
+
+    public const AVAILABLE = [
+        self::BLOG_PUBLIC,
+    ];
+}

--- a/src/Models/BasicAuthenticationRealm.php
+++ b/src/Models/BasicAuthenticationRealm.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
+
+class BasicAuthenticationRealm extends ClusterModel implements Model
+{
+    private string $name;
+    private string $directoryPath;
+    private int $virtualHostId;
+    private int $htpasswdFileId;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): BasicAuthenticationRealm
+    {
+        Validator::value($name)
+            ->maxLength(64)
+            ->pattern('^[a-zA-Z0-9-_ ]+$')
+            ->validate();
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDirectoryPath(): string
+    {
+        return $this->directoryPath;
+    }
+
+    public function setDirectoryPath(string $directoryPath): BasicAuthenticationRealm
+    {
+        $this->directoryPath = $directoryPath;
+
+        return $this;
+    }
+
+    public function getVirtualHostId(): int
+    {
+        return $this->virtualHostId;
+    }
+
+    public function setVirtualHostId(int $virtualHostId): BasicAuthenticationRealm
+    {
+        $this->virtualHostId = $virtualHostId;
+
+        return $this;
+    }
+
+    public function getHtpasswdFileId(): int
+    {
+        return $this->htpasswdFileId;
+    }
+
+    public function setHtpasswdFileId(int $htpasswdFileId): BasicAuthenticationRealm
+    {
+        $this->htpasswdFileId = $htpasswdFileId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): BasicAuthenticationRealm
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): BasicAuthenticationRealm
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): BasicAuthenticationRealm
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): BasicAuthenticationRealm
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): BasicAuthenticationRealm
+    {
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setDirectoryPath(Arr::get($data, 'directory_path'))
+            ->setVirtualHostId(Arr::get($data, 'virtual_host_id'))
+            ->setHtpasswdFileId(Arr::get($data, 'htpasswd_file_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->getName(),
+            'directory_path' => $this->getDirectoryPath(),
+            'virtual_host_id' => $this->getVirtualHostId(),
+            'htpasswd_file_id' => $this->getHtpasswdFileId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}

--- a/src/Models/CmsConfigurationConstant.php
+++ b/src/Models/CmsConfigurationConstant.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\CmsConfigurationConstantName;
+
+class CmsConfigurationConstant extends ClusterModel implements Model
+{
+    private string $name;
+    private mixed $value;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): CmsConfigurationConstant
+    {
+        Validator::value($name)
+            ->valueIn(CmsConfigurationConstantName::AVAILABLE)
+            ->validate();
+
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function setValue(mixed $value): CmsConfigurationConstant
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): CmsConfigurationConstant
+    {
+        return $this
+            ->setName(Arr::get($data, 'name'))
+            ->setValue(Arr::get($data, 'value'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->getName(),
+            'value' => $this->getValue(),
+        ];
+    }
+}

--- a/src/Models/CmsOption.php
+++ b/src/Models/CmsOption.php
@@ -4,10 +4,29 @@ namespace Vdhicts\Cyberfusion\ClusterApi\Models;
 
 use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
 use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
+use Vdhicts\Cyberfusion\ClusterApi\Enums\CmsOptionName;
 
 class CmsOption extends ClusterModel implements Model
 {
+    private string $name;
     private mixed $value;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): CmsOption
+    {
+        Validator::value($name)
+            ->valueIn(CmsOptionName::AVAILABLE)
+            ->validate();
+
+        $this->name = $name;
+
+        return $this;
+    }
 
     public function getValue(): mixed
     {
@@ -24,12 +43,14 @@ class CmsOption extends ClusterModel implements Model
     public function fromArray(array $data): CmsOption
     {
         return $this
+            ->setName(Arr::get($data, 'name'))
             ->setValue(Arr::get($data, 'value'));
     }
 
     public function toArray(): array
     {
         return [
+            'name' => $this->getName(),
             'value' => $this->getValue(),
         ];
     }

--- a/src/Models/CmsOptionName.php
+++ b/src/Models/CmsOptionName.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+
+class CmsOption extends ClusterModel implements Model
+{
+    private mixed $value;
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function setValue(mixed $value): CmsOption
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): CmsOption
+    {
+        return $this
+            ->setValue(Arr::get($data, 'value'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'value' => $this->getValue(),
+        ];
+    }
+}

--- a/src/Models/HtpasswdFile.php
+++ b/src/Models/HtpasswdFile.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+
+class HtpasswdFile extends ClusterModel implements Model
+{
+    private int $unixUserId;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getUnixUserId(): int
+    {
+        return $this->unixUserId;
+    }
+
+    public function setUnixUserId(int $unixUserId): HtpasswdFile
+    {
+        $this->unixUserId = $unixUserId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): HtpasswdFile
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): HtpasswdFile
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): HtpasswdFile
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): HtpasswdFile
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): HtpasswdFile
+    {
+        return $this
+            ->setUnixUserId(Arr::get($data, 'unix_user_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'unix_user_id' => $this->getUnixUserId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}

--- a/src/Models/HtpasswdUser.php
+++ b/src/Models/HtpasswdUser.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Vdhicts\Cyberfusion\ClusterApi\Models;
+
+use Vdhicts\Cyberfusion\ClusterApi\Support\Arr;
+use Vdhicts\Cyberfusion\ClusterApi\Contracts\Model;
+use Vdhicts\Cyberfusion\ClusterApi\Support\Validator;
+
+class HtpasswdUser extends ClusterModel implements Model
+{
+    private string $username;
+    private string $password;
+    private int $htpasswdFileId;
+    private ?int $id = null;
+    private ?int $clusterId = null;
+    private ?string $createdAt = null;
+    private ?string $updatedAt = null;
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(string $username): HtpasswdUser
+    {
+        Validator::value($username)
+            ->maxLength(255)
+            ->pattern('^[a-z0-9-_]+$')
+            ->validate();
+
+        $this->username = $username;
+
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): HtpasswdUser
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getHtpasswdFileId(): int
+    {
+        return $this->htpasswdFileId;
+    }
+
+    public function setHtpasswdFileId(int $htpasswdFileId): HtpasswdUser
+    {
+        $this->htpasswdFileId = $htpasswdFileId;
+
+        return $this;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): HtpasswdUser
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getClusterId(): ?int
+    {
+        return $this->clusterId;
+    }
+
+    public function setClusterId(?int $clusterId): HtpasswdUser
+    {
+        $this->clusterId = $clusterId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): HtpasswdUser
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?string $updatedAt): HtpasswdUser
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function fromArray(array $data): HtpasswdUser
+    {
+        return $this
+            ->setUsername(Arr::get($data, 'username'))
+            ->setPassword(Arr::get($data, 'password'))
+            ->setHtpasswdFileId(Arr::get($data, 'htpasswd_file_id'))
+            ->setId(Arr::get($data, 'id'))
+            ->setClusterId(Arr::get($data, 'cluster_id'))
+            ->setCreatedAt(Arr::get($data, 'created_at'))
+            ->setUpdatedAt(Arr::get($data, 'updated_at'));
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'username' => $this->getUsername(),
+            'password' => $this->getPassword(),
+            'htpasswd_file_id' => $this->getHtpasswdFileId(),
+            'id' => $this->getId(),
+            'cluster_id' => $this->getClusterId(),
+            'created_at' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+        ];
+    }
+}


### PR DESCRIPTION
# Changes

Add CMS options endpoint.

The `name` path parameter is an Enum. Other endpoints that need an Enum do not use the `valueIn` validation that models use for Enums. I don't know if there is a reason for that. If there is, commit https://github.com/vdhicts/cyberfusion-cluster-api-client/commit/7e1476ca8a816dca450cb39cb9ebecba5b51909d can be easily dropped.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
