### PR TITLE
Version 1.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.69.0]
+
+### Added
+
+- Add the `primaryNodeId` attribute to Redis instances.
+
 ## [1.68.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cyberfusion Cluster API client
 
 Easily use the [API of the clusters](https://cluster-api.cyberfusion.nl/) of the hosting company
-[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.141** version of the API.
+[Cyberfusion](https://cyberfusion.nl/). This package was built and tested on the **1.142** version of the API.
 This package is not created or maintained by Cyberfusion.
 
 ## Requirements

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.68.0';
+    private const VERSION = '1.69.0';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/RedisInstances.php
+++ b/src/Endpoints/RedisInstances.php
@@ -76,6 +76,7 @@ class RedisInstances extends Endpoint
             'name',
             'password',
             'max_databases',
+            'primary_node_id',
             'memory_limit',
             'cluster_id',
         ]);
@@ -87,6 +88,7 @@ class RedisInstances extends Endpoint
                 'name',
                 'password',
                 'max_databases',
+                'primary_node_id',
                 'memory_limit',
                 'cluster_id',
             ]));
@@ -121,6 +123,7 @@ class RedisInstances extends Endpoint
             'name',
             'password',
             'max_databases',
+            'primary_node_id',
             'memory_limit',
             'port',
             'unit_name',
@@ -135,6 +138,7 @@ class RedisInstances extends Endpoint
                 'name',
                 'password',
                 'max_databases',
+                'primary_node_id',
                 'memory_limit',
                 'port',
                 'unit_name',

--- a/src/Models/RedisInstance.php
+++ b/src/Models/RedisInstance.php
@@ -12,6 +12,7 @@ class RedisInstance extends ClusterModel implements Model
     private int $maxDatabases;
     private int $port;
     private int $memoryLimit;
+    private int $primaryNodeId;
     private ?string $unitName;
     private ?int $id = null;
     private ?int $clusterId = null;
@@ -83,6 +84,18 @@ class RedisInstance extends ClusterModel implements Model
         return $this;
     }
 
+    public function getPrimaryNodeId(): int
+    {
+        return $this->primaryNodeId;
+    }
+
+    public function setPrimaryNodeId(int $primaryNodeId): RedisInstance
+    {
+        $this->primaryNodeId = $primaryNodeId;
+
+        return $this;
+    }
+
     public function getUnitName(): ?string
     {
         return $this->unitName;
@@ -150,6 +163,7 @@ class RedisInstance extends ClusterModel implements Model
             ->setMaxDatabases(Arr::get($data, 'max_databases'))
             ->setPort(Arr::get($data, 'port'))
             ->setMemoryLimit(Arr::get($data, 'memory_limit'))
+            ->setPrimaryNodeId(Arr::get($data, 'primary_node_id'))
             ->setUnitName(Arr::get($data, 'unit_name'))
             ->setId(Arr::get($data, 'id'))
             ->setClusterId(Arr::get($data, 'cluster_id'))
@@ -164,6 +178,7 @@ class RedisInstance extends ClusterModel implements Model
             'max_databases' => $this->getMaxDatabases(),
             'port' => $this->getPort(),
             'memory_limit' => $this->getMemoryLimit(),
+            'primary_node_id' => $this->getPrimaryNodeId(),
             'unit_name' => $this->getUnitName(),
             'id' => $this->getId(),
             'cluster_id' => $this->getClusterId(),


### PR DESCRIPTION
# Changes

Add the `primaryNodeId` attribute to Redis instances.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)
