### PR TITLE
Version 1.69.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 cluster API. See the changelog of the [cluster API](https://cluster-api.cyberfusion.nl/redoc#section/Changelog) for 
 detailed information.
 
+## [1.69.1]
+
+### Fixed
+
+- Add the required `domainRoot` attribute to virtual host update payload.
+
 ## [1.69.0]
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,7 +20,7 @@ class Client implements ClientContract
 {
     private const CONNECT_TIMEOUT = 60;
     private const TIMEOUT = 180;
-    private const VERSION = '1.69.0';
+    private const VERSION = '1.69.1';
     private const USER_AGENT = 'cyberfusion-cluster-api-client/' . self::VERSION;
 
     private Configuration $configuration;

--- a/src/Endpoints/VirtualHosts.php
+++ b/src/Endpoints/VirtualHosts.php
@@ -156,6 +156,7 @@ class VirtualHosts extends Endpoint
                 'force_ssl',
                 'custom_config',
                 'balancer_backend_name',
+                'domain_root',
                 'allow_override_directives',
                 'allow_override_option_directives',
                 'id',


### PR DESCRIPTION
# Changes

- Add the required `domainRoot` attribute to the virtual host update payload.

# Checks

- [x] The version constant is updated in `Client.php`
- [x] The changelog is updated (when applicable)
- [x] The supported Cluster API version is updated in the README (when applicable)

# Background
The `domainRoot` attribute was added to the validation layer on https://github.com/vdhicts/cyberfusion-cluster-api-client/pull/139, but missed in the `update` call's payload.
